### PR TITLE
Update ghostscript to 9.26

### DIFF
--- a/deps/ghostscript.json
+++ b/deps/ghostscript.json
@@ -13,8 +13,8 @@
     "sources": [
         {
             "type": "archive",
-            "url": "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs925/ghostscript-9.25.tar.xz",
-            "sha256": "a2971a23bf15bbd9ddcd173141b15504e51ddc1d5a0a0144b00a6a8b14a62fed"
+            "url": "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs926/ghostscript-9.26.tar.xz",
+            "sha256": "90ed475f37584f646e9ef829932b2525d5c6fc2e0147e8d611bc50aa0e718598"
         }
     ]
 }


### PR DESCRIPTION
Ghostscript 9.26 is yet another security related related release.
https://www.ghostscript.com/doc/9.26/News.htm