### PR TITLE
enable TLS support in ffmpeg (fixes #32)

### DIFF
--- a/deps/ffmpeg.json
+++ b/deps/ffmpeg.json
@@ -11,6 +11,7 @@
         "--enable-vaapi",
         "--enable-vdpau",
         "--enable-postproc",
+        "--enable-gnutls",
         "--enable-gpl"
     ],
     "cleanup": [


### PR DESCRIPTION
This enables gnutls support in ffmpeg. This is needed for many https streams.
Still needs testing.