### PR TITLE
Revert "Update fmt to 5.3.0"

### DIFF
--- a/deps/fmt.json
+++ b/deps/fmt.json
@@ -12,8 +12,8 @@
     "sources": [
         {
             "type": "archive",
-            "url": "https://github.com/fmtlib/fmt/archive/5.3.0.tar.gz",
-            "sha256": "defa24a9af4c622a7134076602070b45721a43c51598c8456ec6f2c4dbb51c89"
+            "url": "https://github.com/fmtlib/fmt/archive/5.2.1.tar.gz",
+            "sha256": "3c812a18e9f72a88631ab4732a97ce9ef5bcbefb3235e9fd465f059ba204359b"
         }
     ]
 }


### PR DESCRIPTION
This reverts commit 2501db9d936e39b2a7c4a56496c4ac78b00ba672.

see https://github.com/flathub/tv.kodi.Kodi/issues/36

I didn't verify this fixes the issue yet, so lets try the test build when it's done