### PR TITLE
Bump OpenJDK to 11

### DIFF
--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -3,7 +3,7 @@ runtime: org.freedesktop.Platform
 runtime-version: '18.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.openjdk10
+  - org.freedesktop.Sdk.Extension.openjdk11
 finish-args:
   - --device=all
   - --filesystem=xdg-music


### PR DESCRIPTION
OpenJDK 10 is EOL
https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk10#deprecated