### PR TITLE
Disable some static libs

### DIFF
--- a/deps/libopenmpt.json
+++ b/deps/libopenmpt.json
@@ -1,8 +1,12 @@
 {
     "name": "libopenmpt",
+    "cleanup": [
+        "/include"
+    ],
     "config-opts": [
         "--without-portaudio",
-        "--without-portaudiocpp"
+        "--without-portaudiocpp",
+        "--enable-static=no"
     ],
     "sources": [
         {


### PR DESCRIPTION
`libopenmpt.a` weights 113MB (whole kodi flatpak is 429.5 MB) and shouldn't be needed for anything. Shared libs should be sufficient.