### PR TITLE
Update to 18.8 Leia

### DIFF
--- a/tv.kodi.Kodi.appdata.xml
+++ b/tv.kodi.Kodi.appdata.xml
@@ -39,7 +39,7 @@
     </screenshots>
     <releases>
         <release date="2020-07-28" version="18.8-Leia"/>
-	<release date="2020-05-21" version="18.7-Leia"/>
+        <release date="2020-05-21" version="18.7-Leia"/>
         <release date="2020-02-29" version="18.6-Leia"/>
         <release date="2019-11-18" version="18.5-Leia"/>
         <release date="2019-08-31" version="18.4-Leia"/>

--- a/tv.kodi.Kodi.appdata.xml
+++ b/tv.kodi.Kodi.appdata.xml
@@ -38,7 +38,8 @@
         <screenshot type="default">https://kodi.tv/sites/default/files/styles/hero_16_9/public/feature/field_image/skin.bello__0.jpg</screenshot>
     </screenshots>
     <releases>
-        <release date="2020-05-21" version="18.7-Leia"/>
+        <release date="2020-07-28" version="18.8-Leia"/>
+	<release date="2020-05-21" version="18.7-Leia"/>
         <release date="2020-02-29" version="18.6-Leia"/>
         <release date="2019-11-18" version="18.5-Leia"/>
         <release date="2019-08-31" version="18.4-Leia"/>

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -70,8 +70,8 @@ modules:
       - /share/doc
     sources: &kodi-sources
       - type: archive
-        url: https://github.com/xbmc/xbmc/archive/18.7-Leia.tar.gz
-        sha256: f6bb2ad9d8ca27d1b6bf68690d699f5e2bf3d0c7e5700d8e564b7583054c434e
+        url: https://github.com/xbmc/xbmc/archive/18.8-Leia.tar.gz
+        sha256: 6deb28f725880b1ab6c5920b55ef1190a79b0684ffb30b6e13b199d23a0af296
       - type: patch
         path: kodi-sh-in.patch
       - type: file


### PR DESCRIPTION
https://kodi.tv/article/kodi-leia-188-release
- Fixes a severe security issue in gnutls
- Other significant library/compatibility updates
- Gets client/server on MariaDB 10.5.4 working for Android
- Fixes video database access for Ubuntu 20.4 and other distros using earlier libfmt versions (search and other filtering failed)
- Fixes subtitle handling from archives
- Fixes CDDB access
- Makes minor improvements to logging and memory reporting/display
- Fixes EDLs where skip points are at the very start of a file
- Contains code improvements to fix specific events, e.g. race conditions in the EPG or "pause" on end of streams on Android
- Enables alpha blending for the video player (Windows)
- Better handles specific exceptions (Android, mostly)