### PR TITLE
Switch to shared-modules version of fluidsynth2 module

### DIFF
--- a/addons/audiodecoder.fluidsynth/audiodecoder.fluidsynth.json
+++ b/addons/audiodecoder.fluidsynth/audiodecoder.fluidsynth.json
@@ -10,16 +10,6 @@
         }
     ],
     "modules": [
-        {
-            "name": "fluidsynth",
-            "buildsystem": "cmake-ninja",
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://github.com/FluidSynth/fluidsynth/archive/v2.2.3.tar.gz",
-                    "sha256": "b31807cb0f88e97f3096e2b378c9815a6acfdc20b0b14f97936d905b536965c4"
-                }
-            ]
-        }
+        "../../shared-modules/linux-audio/fluidsynth2.json"
     ]
 }


### PR DESCRIPTION
`fluidsynth2` [available](https://github.com/flathub/shared-modules/blob/master/linux-audio/fluidsynth2.json) now in `shared-modules`. Would be nice to switch on this version. Thanks.