### PR TITLE
use upstream definitions for addons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 build-dir/
 build.log
 repo/
+tools/binary_addons_repo_tmp

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ PROJECT ?= tv.kodi.Kodi
 
 .PHONY: build build-i386 flatpak install run clean
 
+update-addons:
+	cd tools && python3 addon_updater.py -r
 build:
 	flatpak-builder build-dir $(PROJECT).yml --repo=repo --force-clean --ccache 2>&1 | tee -a build.log
 build-i386:

--- a/README.md
+++ b/README.md
@@ -22,4 +22,6 @@ The list of binary addons in each branch of Kodi may be found
 [here](https://github.com/xbmc/xbmc/tree/master/tools/depends/target). Kodi
 releases are found [here](https://github.com/xbmc/xbmc/releases).
 
+`make update-addons` can help updating existing addons and also list missing ones
+
 You can contribute by updating addons, modules and the Kodi version.

--- a/addons/audiodecoder.2sf/audiodecoder.2sf.json
+++ b/addons/audiodecoder.2sf/audiodecoder.2sf.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/audiodecoder.2sf",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/audiodecoder.2sf/audiodecoder.2sf.json
+++ b/addons/audiodecoder.2sf/audiodecoder.2sf.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/audiodecoder.2sf",
-            "tag": "20.1.0-Nexus",
-            "commit": "3ffa8efae3ce766364849679bb790d8d6652465d"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/audiodecoder.asap/audiodecoder.asap.json
+++ b/addons/audiodecoder.asap/audiodecoder.asap.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/audiodecoder.asap",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/audiodecoder.asap/audiodecoder.asap.json
+++ b/addons/audiodecoder.asap/audiodecoder.asap.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/audiodecoder.asap",
-            "tag": "20.1.0-Nexus",
-            "commit": "9c91b4320358e242064bf985c7305362c3a095e8"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/audiodecoder.dumb/audiodecoder.dumb.json
+++ b/addons/audiodecoder.dumb/audiodecoder.dumb.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/audiodecoder.dumb",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/audiodecoder.dumb/audiodecoder.dumb.json
+++ b/addons/audiodecoder.dumb/audiodecoder.dumb.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/audiodecoder.dumb",
-            "tag": "20.1.0-Nexus",
-            "commit": "296b086b6d5be43f66af17ecbdb8febec3fc51f8"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/audiodecoder.fluidsynth/audiodecoder.fluidsynth.json
+++ b/addons/audiodecoder.fluidsynth/audiodecoder.fluidsynth.json
@@ -1,15 +1,48 @@
 {
     "name": "audiodecoder.fluidsynth",
     "buildsystem": "cmake-ninja",
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+         "-DCMAKE_BUILD_TYPE=Release"
+    ],
     "sources": [
         {
             "type": "git",
             "url": "https://github.com/xbmc/audiodecoder.fluidsynth",
-            "tag": "20.1.0-Nexus",
-            "commit": "52cc10a27af3d4d1dfa47ff146909f8815dea2d7"
+            "branch": "Nexus"
         }
     ],
     "modules": [
-        "../../shared-modules/linux-audio/fluidsynth2.json"
+        {
+            "name": "fluidsynth",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DLIB_SUFFIX="
+            ],
+            "build-options": {
+                "no-debuginfo": true,
+                "cflags": "-g0",
+                "cxxflags": "-g0"
+            },
+            "cleanup": [
+                "/bin",
+                "/include",
+                "/lib/pkgconfig",
+                "/share/man",
+                "*.so"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/FluidSynth/fluidsynth/archive/v2.2.3.tar.gz",
+                    "sha256": "b31807cb0f88e97f3096e2b378c9815a6acfdc20b0b14f97936d905b536965c4"
+                }
+            ]
+        }
     ]
 }

--- a/addons/audiodecoder.gme/audiodecoder.gme.json
+++ b/addons/audiodecoder.gme/audiodecoder.gme.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/audiodecoder.gme",
-            "tag": "20.1.0-Nexus",
-            "commit": "926778127fa98b86a97be4c5b98049c8016247eb"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/audiodecoder.gme/audiodecoder.gme.json
+++ b/addons/audiodecoder.gme/audiodecoder.gme.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/audiodecoder.gme",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/audiodecoder.gsf/audiodecoder.gsf.json
+++ b/addons/audiodecoder.gsf/audiodecoder.gsf.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/audiodecoder.gsf",
-            "tag": "20.1.0-Nexus",
-            "commit": "a25bc8caf0e07e6dd886ef5cfe67dc2fc3973c56"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/audiodecoder.gsf/audiodecoder.gsf.json
+++ b/addons/audiodecoder.gsf/audiodecoder.gsf.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/audiodecoder.gsf",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/audiodecoder.hvl/audiodecoder.hvl.json
+++ b/addons/audiodecoder.hvl/audiodecoder.hvl.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/audiodecoder.hvl",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/audiodecoder.hvl/audiodecoder.hvl.json
+++ b/addons/audiodecoder.hvl/audiodecoder.hvl.json
@@ -1,0 +1,11 @@
+{
+    "name": "audiodecoder.hvl",
+    "buildsystem": "cmake-ninja",
+    "sources": [
+        {
+            "type": "git",
+            "url": "https://github.com/xbmc/audiodecoder.hvl",
+            "branch": "Nexus"
+        }
+    ]
+}

--- a/addons/audiodecoder.modplug/audiodecoder.modplug.json
+++ b/addons/audiodecoder.modplug/audiodecoder.modplug.json
@@ -13,8 +13,14 @@
             "name": "libmodplug",
             "buildsystem": "cmake-ninja",
             "config-opts": [
-                "-DBUILD_SHARED_LIBS=ON"
+                "-DBUILD_SHARED_LIBS=ON",
+                "-DCMAKE_BUILD_TYPE=Release"
             ],
+            "build-options": {
+                "no-debuginfo": true,
+                "cflags": "-g0",
+                "cxxflags": "-g0"
+            },
             "sources": [
                 {
                     "type": "archive",
@@ -23,5 +29,13 @@
                 }
             ]
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/audiodecoder.modplug/audiodecoder.modplug.json
+++ b/addons/audiodecoder.modplug/audiodecoder.modplug.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/audiodecoder.modplug",
-            "tag": "20.1.0-Nexus",
-            "commit": "fd6ac046092cceaaf79a16ecb238cedcfa37768e"
+            "branch": "Nexus"
         }
     ],
     "modules": [

--- a/addons/audiodecoder.ncsf/audiodecoder.ncsf.json
+++ b/addons/audiodecoder.ncsf/audiodecoder.ncsf.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/audiodecoder.ncsf",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/audiodecoder.ncsf/audiodecoder.ncsf.json
+++ b/addons/audiodecoder.ncsf/audiodecoder.ncsf.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/audiodecoder.ncsf",
-            "tag": "20.1.0-Nexus",
-            "commit": "e720325390cf63b31f8b592577767419527ea92e"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/audiodecoder.nosefart/audiodecoder.nosefart.json
+++ b/addons/audiodecoder.nosefart/audiodecoder.nosefart.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/audiodecoder.nosefart",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/audiodecoder.nosefart/audiodecoder.nosefart.json
+++ b/addons/audiodecoder.nosefart/audiodecoder.nosefart.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/audiodecoder.nosefart",
-            "tag": "20.1.0-Nexus",
-            "commit": "f69b45a72a4cf963c00544da4b0f69f6b0495059"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/audiodecoder.openmpt/audiodecoder.openmpt.json
+++ b/addons/audiodecoder.openmpt/audiodecoder.openmpt.json
@@ -16,6 +16,11 @@
                 "--disable-examples",
                 "--disable-tests"
             ],
+            "build-options": {
+                "no-debuginfo": true,
+                "cflags": "-g0",
+                "cxxflags": "-g0"
+            },
             "cleanup": [
                 "/include"
             ],
@@ -27,5 +32,13 @@
                 }
             ]
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/audiodecoder.openmpt/audiodecoder.openmpt.json
+++ b/addons/audiodecoder.openmpt/audiodecoder.openmpt.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/audiodecoder.openmpt",
-            "tag": "20.1.0-Nexus",
-            "commit": "ff025d2c2994d38e383afce3afa56b3be6be9ee1"
+            "branch": "Nexus"
         }
     ],
     "modules": [

--- a/addons/audiodecoder.organya/audiodecoder.organya.json
+++ b/addons/audiodecoder.organya/audiodecoder.organya.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/audiodecoder.organya",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/audiodecoder.organya/audiodecoder.organya.json
+++ b/addons/audiodecoder.organya/audiodecoder.organya.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/audiodecoder.organya",
-            "tag": "20.1.0-Nexus",
-            "commit": "4931b7c6774444f47595ccf396f9e12b21c60c95"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/audiodecoder.qsf/audiodecoder.qsf.json
+++ b/addons/audiodecoder.qsf/audiodecoder.qsf.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/audiodecoder.qsf",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/audiodecoder.qsf/audiodecoder.qsf.json
+++ b/addons/audiodecoder.qsf/audiodecoder.qsf.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/audiodecoder.qsf",
-            "tag": "20.1.0-Nexus",
-            "commit": "81a73e99ee9ba633728647a57bc545cb82a32294"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/audiodecoder.sacd/audiodecoder.sacd.json
+++ b/addons/audiodecoder.sacd/audiodecoder.sacd.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/audiodecoder.sacd",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/audiodecoder.sacd/audiodecoder.sacd.json
+++ b/addons/audiodecoder.sacd/audiodecoder.sacd.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/audiodecoder.sacd",
-            "tag": "20.1.0-Nexus",
-            "commit": "b826dc6090d7046420e8a3e422b4eee8268307c8"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/audiodecoder.sidplay/audiodecoder.sidplay.json
+++ b/addons/audiodecoder.sidplay/audiodecoder.sidplay.json
@@ -1,57 +1,56 @@
 {
-  "name": "audiodecoder.sidplay",
-  "buildsystem": "cmake-ninja",
-  "sources": [
-    {
-      "type": "git",
-      "url": "https://github.com/xbmc/audiodecoder.sidplay",
-      "tag": "20.1.0-Nexus",
-      "commit": "5f90a5043fee2e23c4462ffb0c4865170d780456"
-    }
-  ],
-  "modules": [
-    {
-      "name": "sidplay2",
-      "buildsystem": "autotools",
-      "sources": [
+    "name": "audiodecoder.sidplay",
+    "buildsystem": "cmake-ninja",
+    "sources": [
         {
-          "type": "archive",
-          "url": "http://mirrors.kodi.tv/build-deps/sources/sidplay-libs-2.1.1.tar.gz",
-          "sha256": "e9a24ada48215a46d2c232a70c5601bc9505e997f120e8f2ba3713e09e28d1f9"
-        },
-        {
-          "type": "patch",
-          "path": "01-m4-tests.patch"
-        },
-        {
-          "type": "patch",
-          "path": "02-inherited.patch"
-        },
-        {
-          "type": "patch",
-          "path": "03-operator.patch"
-        },
-        {
-          "type": "patch",
-          "path": "04-includes.patch"
-        },
-        {
-          "type": "patch",
-          "path": "05-enable-pic.patch"
-        },
-        {
-          "type": "patch",
-          "path": "06-include-macros.patch"
-        },
-        {
-          "type": "patch",
-          "path": "07-replace-linux-header.patch"
-        },
-        {
-          "type": "patch",
-          "path": "08-c++11-narrowing.patch"
+            "type": "git",
+            "url": "https://github.com/xbmc/audiodecoder.sidplay",
+            "branch": "Nexus"
         }
-      ]
-    }
-  ]
+    ],
+    "modules": [
+        {
+            "name": "sidplay2",
+            "buildsystem": "autotools",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://mirrors.kodi.tv/build-deps/sources/sidplay-libs-2.1.1.tar.gz",
+                    "sha256": "e9a24ada48215a46d2c232a70c5601bc9505e997f120e8f2ba3713e09e28d1f9"
+                },
+                {
+                    "type": "patch",
+                    "path": "01-m4-tests.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "02-inherited.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "03-operator.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "04-includes.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "05-enable-pic.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "06-include-macros.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "07-replace-linux-header.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "08-c++11-narrowing.patch"
+                }
+            ]
+        }
+    ]
 }

--- a/addons/audiodecoder.sidplay/audiodecoder.sidplay.json
+++ b/addons/audiodecoder.sidplay/audiodecoder.sidplay.json
@@ -12,6 +12,11 @@
         {
             "name": "sidplay2",
             "buildsystem": "autotools",
+            "build-options": {
+                "no-debuginfo": true,
+                "cflags": "-g0",
+                "cxxflags": "-g0"
+            },
             "sources": [
                 {
                     "type": "archive",
@@ -52,5 +57,13 @@
                 }
             ]
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/audiodecoder.snesapu/audiodecoder.snesapu.json
+++ b/addons/audiodecoder.snesapu/audiodecoder.snesapu.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/audiodecoder.snesapu",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/audiodecoder.snesapu/audiodecoder.snesapu.json
+++ b/addons/audiodecoder.snesapu/audiodecoder.snesapu.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/audiodecoder.snesapu",
-            "tag": "20.1.0-Nexus",
-            "commit": "5b37bc53beffeacdf195681e950abbb005e5cad3"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/audiodecoder.ssf/audiodecoder.ssf.json
+++ b/addons/audiodecoder.ssf/audiodecoder.ssf.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/audiodecoder.ssf",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/audiodecoder.ssf/audiodecoder.ssf.json
+++ b/addons/audiodecoder.ssf/audiodecoder.ssf.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/audiodecoder.ssf",
-            "tag": "20.1.0-Nexus",
-            "commit": "8ba4847002868d2ea4f67d39a9e06fb68e54c98d"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/audiodecoder.stsound/audiodecoder.stsound.json
+++ b/addons/audiodecoder.stsound/audiodecoder.stsound.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/audiodecoder.stsound",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/audiodecoder.stsound/audiodecoder.stsound.json
+++ b/addons/audiodecoder.stsound/audiodecoder.stsound.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/audiodecoder.stsound",
-            "tag": "20.1.0-Nexus",
-            "commit": "baea6af0b937bd2c85703127cdcbcd7d3fbda1ea"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/audiodecoder.timidity/audiodecoder.timidity.json
+++ b/addons/audiodecoder.timidity/audiodecoder.timidity.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/audiodecoder.timidity",
-            "tag": "20.1.0-Nexus",
-            "commit": "dcf3b92df137d9ebc735c52484b20236e35415b9"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/audiodecoder.timidity/audiodecoder.timidity.json
+++ b/addons/audiodecoder.timidity/audiodecoder.timidity.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/audiodecoder.timidity",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/audiodecoder.upse/audiodecoder.upse.json
+++ b/addons/audiodecoder.upse/audiodecoder.upse.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/audiodecoder.upse",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/audiodecoder.upse/audiodecoder.upse.json
+++ b/addons/audiodecoder.upse/audiodecoder.upse.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/audiodecoder.upse",
-            "tag": "20.1.0-Nexus",
-            "commit": "7c9fdb494d50ac69ee32cdbe7d47f1259c8fd509"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/audiodecoder.usf/audiodecoder.usf.json
+++ b/addons/audiodecoder.usf/audiodecoder.usf.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/audiodecoder.usf",
-            "tag": "20.1.0-Nexus",
-            "commit": "324ea19999fbeff3835d9b83137460024dc7c49f"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/audiodecoder.usf/audiodecoder.usf.json
+++ b/addons/audiodecoder.usf/audiodecoder.usf.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/audiodecoder.usf",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/audiodecoder.vgmstream/audiodecoder.vgmstream.json
+++ b/addons/audiodecoder.vgmstream/audiodecoder.vgmstream.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/audiodecoder.vgmstream",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/audiodecoder.vgmstream/audiodecoder.vgmstream.json
+++ b/addons/audiodecoder.vgmstream/audiodecoder.vgmstream.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/audiodecoder.vgmstream",
-            "tag": "20.1.0-Nexus",
-            "commit": "372fb204a4091f7cbd8fecc9fa0d316ab5e04724"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/audiodecoder.wsr/audiodecoder.wsr.json
+++ b/addons/audiodecoder.wsr/audiodecoder.wsr.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/audiodecoder.wsr",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/audiodecoder.wsr/audiodecoder.wsr.json
+++ b/addons/audiodecoder.wsr/audiodecoder.wsr.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/audiodecoder.wsr",
-            "tag": "20.1.0-Nexus",
-            "commit": "7efd87c74fd511513b6e8a38262f0ec271c5ccd7"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/audioencoder.flac/audioencoder.flac.json
+++ b/addons/audioencoder.flac/audioencoder.flac.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/audioencoder.flac",
-            "tag": "20.1.0-Nexus",
-            "commit": "c00b948a3ec5b0b86c86dec84313d74b1ab40ab0"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/audioencoder.flac/audioencoder.flac.json
+++ b/addons/audioencoder.flac/audioencoder.flac.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/audioencoder.flac",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/audioencoder.lame/audioencoder.lame.json
+++ b/addons/audioencoder.lame/audioencoder.lame.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/audioencoder.lame",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/audioencoder.lame/audioencoder.lame.json
+++ b/addons/audioencoder.lame/audioencoder.lame.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/audioencoder.lame",
-            "tag": "20.2.0-Nexus",
-            "commit": "81b0dce89209ae4771f747509e88fedf036ebf1c"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/audioencoder.vorbis/audioencoder.vorbis.json
+++ b/addons/audioencoder.vorbis/audioencoder.vorbis.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/audioencoder.vorbis",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/audioencoder.vorbis/audioencoder.vorbis.json
+++ b/addons/audioencoder.vorbis/audioencoder.vorbis.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/audioencoder.vorbis",
-            "tag": "20.1.0-Nexus",
-            "commit": "6b54cf85e4a41d978eedfa4f37da644a5a4d94ed"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/audioencoder.wav/audioencoder.wav.json
+++ b/addons/audioencoder.wav/audioencoder.wav.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/audioencoder.wav",
-            "tag": "20.1.0-Nexus",
-            "commit": "6cf6570d060693581caf55204d2a0343f7991ad7"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/audioencoder.wav/audioencoder.wav.json
+++ b/addons/audioencoder.wav/audioencoder.wav.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/audioencoder.wav",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/game.libretro.2048/game.libretro.2048.json
+++ b/addons/game.libretro.2048/game.libretro.2048.json
@@ -19,5 +19,13 @@
                 }
             ]
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/game.libretro.2048/game.libretro.2048.json
+++ b/addons/game.libretro.2048/game.libretro.2048.json
@@ -1,24 +1,23 @@
 {
-  "name": "game.libretro.2048",
-  "buildsystem": "cmake-ninja",
-  "sources": [
-    {
-      "type": "git",
-      "url": "https://github.com/kodi-game/game.libretro.2048",
-      "tag": "1.0.0.122-Nexus",
-      "commit": "f563cd71a06f6a0ce6b4e19a6a5ae57d13834bf0"
-    }
-  ],
-  "modules": [
-    {
-      "name": "2048",
-      "sources": [
+    "name": "game.libretro.2048",
+    "buildsystem": "cmake-ninja",
+    "sources": [
         {
-          "type": "archive",
-          "url": "https://github.com/libretro/libretro-2048/archive/20051e140346fb56376b59f41f28ef40f8ad7fb8.tar.gz",
-          "sha256": "6cccc6ddefcd065b13aa01881ad82966eb5377657a97757c172c4e82f955780f"
+            "type": "git",
+            "url": "https://github.com/kodi-game/game.libretro.2048",
+            "branch": "master"
         }
-      ]
-    }
-  ]
+    ],
+    "modules": [
+        {
+            "name": "2048",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/libretro/libretro-2048/archive/20051e140346fb56376b59f41f28ef40f8ad7fb8.tar.gz",
+                    "sha256": "6cccc6ddefcd065b13aa01881ad82966eb5377657a97757c172c4e82f955780f"
+                }
+            ]
+        }
+    ]
 }

--- a/addons/game.libretro.mrboom/game.libretro.mrboom.json
+++ b/addons/game.libretro.mrboom/game.libretro.mrboom.json
@@ -19,5 +19,13 @@
                 }
             ]
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/game.libretro.mrboom/game.libretro.mrboom.json
+++ b/addons/game.libretro.mrboom/game.libretro.mrboom.json
@@ -1,24 +1,23 @@
 {
-  "name": "game.libretro.mrboom",
-  "buildsystem": "cmake-ninja",
-  "sources": [
-    {
-      "type": "git",
-      "url": "https://github.com/kodi-game/game.libretro.mrboom",
-      "tag": "5.2.0.131-Nexus",
-      "commit": "156e0e4a031fe7b7245f9fed44c78ae052cd16a6"
-    }
-  ],
-  "modules": [
-    {
-      "name": "mrboom",
-      "sources": [
+    "name": "game.libretro.mrboom",
+    "buildsystem": "cmake-ninja",
+    "sources": [
         {
-          "type": "archive",
-          "url": "https://github.com/Javanaise/mrboom-libretro/releases/download/5.2/MrBoom-src-5.2.454d614.tar.gz",
-          "sha256": "50e4fe4bc74b23ac441499c756c4575dfe9faab9e787a3ab942a856ac63cf10d"
+            "type": "git",
+            "url": "https://github.com/kodi-game/game.libretro.mrboom",
+            "branch": "master"
         }
-      ]
-    }
-  ]
+    ],
+    "modules": [
+        {
+            "name": "mrboom",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/Javanaise/mrboom-libretro/releases/download/5.2/MrBoom-src-5.2.454d614.tar.gz",
+                    "sha256": "50e4fe4bc74b23ac441499c756c4575dfe9faab9e787a3ab942a856ac63cf10d"
+                }
+            ]
+        }
+    ]
 }

--- a/addons/game.libretro/game.libretro.json
+++ b/addons/game.libretro/game.libretro.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/kodi-game/game.libretro",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/game.libretro/game.libretro.json
+++ b/addons/game.libretro/game.libretro.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro",
-            "tag": "20.0.0-Nexus",
-            "commit": "399a206df12ef130c5e43d8271353e405c8dcbc3"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/imagedecoder.heif/imagedecoder.heif.json
+++ b/addons/imagedecoder.heif/imagedecoder.heif.json
@@ -13,12 +13,18 @@
             "name": "libheif",
             "buildsystem": "cmake-ninja",
             "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release",
                 "-DWITH_EXAMPLES=0",
                 "-DWITH_X265=0",
                 "-DWITH_RAV1E=0",
                 "-DWITH_AOM=0",
                 "-DWITH_DAV1D=0"
             ],
+            "build-options": {
+                "no-debuginfo": true,
+                "cflags": "-g0",
+                "cxxflags": "-g0"
+            },
             "sources": [
                 {
                     "type": "archive",
@@ -30,6 +36,11 @@
         {
             "name": "libde265",
             "buildsystem": "cmake-ninja",
+            "build-options": {
+                "no-debuginfo": true,
+                "cflags": "-g0",
+                "cxxflags": "-g0"
+            },
             "sources": [
                 {
                     "type": "archive",
@@ -38,5 +49,13 @@
                 }
             ]
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/imagedecoder.heif/imagedecoder.heif.json
+++ b/addons/imagedecoder.heif/imagedecoder.heif.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/imagedecoder.heif",
-            "tag": "20.0.0-Nexus",
-            "commit": "6942534b2266ec2ae4c9fb6629ac0663324506c6"
+            "branch": "Nexus"
         }
     ],
     "modules": [

--- a/addons/imagedecoder.mpo/imagedecoder.mpo.json
+++ b/addons/imagedecoder.mpo/imagedecoder.mpo.json
@@ -8,5 +8,13 @@
             "url": "https://github.com/xbmc/imagedecoder.mpo",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/imagedecoder.mpo/imagedecoder.mpo.json
+++ b/addons/imagedecoder.mpo/imagedecoder.mpo.json
@@ -6,8 +6,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/imagedecoder.mpo",
-            "tag": "20.0.0-Nexus",
-            "commit": "129c7482f9c76e287aeadd3bfd2be40555b5bda0"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/imagedecoder.raw/imagedecoder.raw.json
+++ b/addons/imagedecoder.raw/imagedecoder.raw.json
@@ -11,6 +11,11 @@
     "modules": [
         {
             "name": "libraw",
+            "build-options": {
+                "no-debuginfo": true,
+                "cflags": "-g0",
+                "cxxflags": "-g0"
+            },
             "sources": [
                 {
                     "type": "archive",
@@ -26,5 +31,13 @@
                 }
             ]
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/imagedecoder.raw/imagedecoder.raw.json
+++ b/addons/imagedecoder.raw/imagedecoder.raw.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/imagedecoder.raw",
-            "tag": "20.0.0-Nexus",
-            "commit": "8c384a6a9eb9c44169bdc5ae8eff34fb0ab82c68"
+            "branch": "Nexus"
         }
     ],
     "modules": [

--- a/addons/inputstream.adaptive/inputstream.adaptive.json
+++ b/addons/inputstream.adaptive/inputstream.adaptive.json
@@ -1,23 +1,23 @@
 {
-  "name": "inputstream.adaptive",
-  "buildsystem": "cmake-ninja",
-  "config-opts": [
-    "-DBUILD_TESTING=OFF",
-    "-DENABLE_INTERNAL_BENTO4=ON",
-    "-DBENTO4_URL=bento4_src"
-  ],
-  "sources": [
-    {
-      "type": "git",
-      "url": "https://github.com/xbmc/inputstream.adaptive",
-      "commit": "785d2b10542f84417189409044b1165d47df23e2"
-    },
-    {
-      "type": "archive",
-      "url": "https://github.com/axiomatic-systems/Bento4/archive/refs/tags/v1.6.0-639.tar.gz",
-      "sha256": "9f3eb912207d7ed9c1e6e05315083404b32a11f8aacd604a9b2bdcb10bf79eb9",
-      "dest": "bento4_src",
-      "dest-filename": "bento4.tar.gz"
-    }
-  ]
+    "name": "inputstream.adaptive",
+    "buildsystem": "cmake-ninja",
+    "config-opts": [
+        "-DBUILD_TESTING=OFF",
+        "-DENABLE_INTERNAL_BENTO4=ON",
+        "-DBENTO4_URL=bento4_src"
+    ],
+    "sources": [
+        {
+            "type": "git",
+            "url": "https://github.com/xbmc/inputstream.adaptive",
+            "branch": "Nexus"
+        },
+        {
+            "type": "archive",
+            "url": "https://github.com/axiomatic-systems/Bento4/archive/refs/tags/v1.6.0-639.tar.gz",
+            "sha256": "9f3eb912207d7ed9c1e6e05315083404b32a11f8aacd604a9b2bdcb10bf79eb9",
+            "dest": "bento4_src",
+            "dest-filename": "bento4.tar.gz"
+        }
+    ]
 }

--- a/addons/inputstream.adaptive/inputstream.adaptive.json
+++ b/addons/inputstream.adaptive/inputstream.adaptive.json
@@ -4,7 +4,8 @@
     "config-opts": [
         "-DBUILD_TESTING=OFF",
         "-DENABLE_INTERNAL_BENTO4=ON",
-        "-DBENTO4_URL=bento4_src"
+        "-DBENTO4_URL=bento4_src",
+        "-DCMAKE_BUILD_TYPE=Release"
     ],
     "sources": [
         {
@@ -19,5 +20,10 @@
             "dest": "bento4_src",
             "dest-filename": "bento4.tar.gz"
         }
-    ]
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    }
 }

--- a/addons/inputstream.ffmpegdirect/inputstream.ffmpegdirect.json
+++ b/addons/inputstream.ffmpegdirect/inputstream.ffmpegdirect.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/inputstream.ffmpegdirect",
-            "tag": "20.0.1-Nexus",
-            "commit": "471a793f2996dcdae9687fc8c9b1f62953f3b829"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/inputstream.ffmpegdirect/inputstream.ffmpegdirect.json
+++ b/addons/inputstream.ffmpegdirect/inputstream.ffmpegdirect.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/inputstream.ffmpegdirect",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/inputstream.rtmp/inputstream.rtmp.json
+++ b/addons/inputstream.rtmp/inputstream.rtmp.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/inputstream.rtmp",
-            "tag": "20.0.0-Nexus",
-            "commit": "936c371a6f2390e49279fdcbdd587dd9d87dd0ed"
+            "branch": "Nexus"
         }
     ],
     "modules": [

--- a/addons/inputstream.rtmp/inputstream.rtmp.json
+++ b/addons/inputstream.rtmp/inputstream.rtmp.json
@@ -18,6 +18,11 @@
                 "make -C librtmp",
                 "make -C librtmp install PREFIX=/app"
             ],
+            "build-options": {
+                "no-debuginfo": true,
+                "cflags": "-g0",
+                "cxxflags": "-g0"
+            },
             "sources": [
                 {
                     "type": "archive",
@@ -26,5 +31,13 @@
                 }
             ]
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/peripheral.joystick/peripheral.joystick.json
+++ b/addons/peripheral.joystick/peripheral.joystick.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/peripheral.joystick",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/peripheral.joystick/peripheral.joystick.json
+++ b/addons/peripheral.joystick/peripheral.joystick.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/peripheral.joystick",
-            "tag": "20.0.0-Nexus",
-            "commit": "9d8b391801532c77b80f1a261faa189cf393f3ac"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/peripheral.xarcade/peripheral.xarcade.json
+++ b/addons/peripheral.xarcade/peripheral.xarcade.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/peripheral.xarcade",
-            "tag": "20.0.1-Nexus",
-            "commit": "0d7e47022c2edaaff5e9b7999199ed687bbc90b7"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/peripheral.xarcade/peripheral.xarcade.json
+++ b/addons/peripheral.xarcade/peripheral.xarcade.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/kodi-game/peripheral.xarcade",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/pvr.argustv/pvr.argustv.json
+++ b/addons/pvr.argustv/pvr.argustv.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/kodi-pvr/pvr.argustv",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/pvr.argustv/pvr.argustv.json
+++ b/addons/pvr.argustv/pvr.argustv.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.argustv",
-            "tag": "20.1.0-Nexus",
-            "commit": "7960df916236aff397ee7da806e1626d4ad91a09"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/pvr.demo/pvr.demo.json
+++ b/addons/pvr.demo/pvr.demo.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.demo",
-            "tag": "20.3.1-Nexus",
-            "commit": "afc348575a7180dcb502a0db16bcea7c9175bd7d"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/pvr.demo/pvr.demo.json
+++ b/addons/pvr.demo/pvr.demo.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/kodi-pvr/pvr.demo",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/pvr.dvblink/pvr.dvblink.json
+++ b/addons/pvr.dvblink/pvr.dvblink.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/kodi-pvr/pvr.dvblink",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/pvr.dvblink/pvr.dvblink.json
+++ b/addons/pvr.dvblink/pvr.dvblink.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.dvblink",
-            "tag": "20.1.0-Nexus",
-            "commit": "bd2ef04645b493f69f997e37c34694316eba539b"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/pvr.dvbviewer/pvr.dvbviewer.json
+++ b/addons/pvr.dvbviewer/pvr.dvbviewer.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.dvbviewer",
-            "tag": "20.1.0-Nexus",
-            "commit": "52e57f9fe0070bb862c9d30cff356ca36e84251e"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/pvr.dvbviewer/pvr.dvbviewer.json
+++ b/addons/pvr.dvbviewer/pvr.dvbviewer.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/kodi-pvr/pvr.dvbviewer",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/pvr.filmon/pvr.filmon.json
+++ b/addons/pvr.filmon/pvr.filmon.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/kodi-pvr/pvr.filmon",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/pvr.filmon/pvr.filmon.json
+++ b/addons/pvr.filmon/pvr.filmon.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.filmon",
-            "tag": "20.1.0-Nexus",
-            "commit": "76c444fedfd98f7d42abfc26f66601f64522dad8"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/pvr.freebox/pvr.freebox.json
+++ b/addons/pvr.freebox/pvr.freebox.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/aassif/pvr.freebox",
-            "tag": "20.1.0-Nexus",
-            "commit": "eed099ce8222e96924b41b4e7857c29a40f13a56"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/pvr.freebox/pvr.freebox.json
+++ b/addons/pvr.freebox/pvr.freebox.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/aassif/pvr.freebox",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/pvr.hdhomerun/pvr.hdhomerun.json
+++ b/addons/pvr.hdhomerun/pvr.hdhomerun.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.hdhomerun",
-            "tag": "20.1.0-Nexus",
-            "commit": "7edf4161b3ded5c1fd017cf20003b4279996897b"
+            "branch": "Nexus"
         }
     ],
     "modules": [

--- a/addons/pvr.hdhomerun/pvr.hdhomerun.json
+++ b/addons/pvr.hdhomerun/pvr.hdhomerun.json
@@ -12,6 +12,14 @@
         {
             "name": "libhdhomerun",
             "buildsystem": "cmake-ninja",
+            "build-options": {
+                "no-debuginfo": true,
+                "cflags": "-g0",
+                "cxxflags": "-g0"
+            },
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release"
+            ],
             "sources": [
                 {
                     "type": "archive",
@@ -24,5 +32,13 @@
                 }
             ]
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/pvr.hts/pvr.hts.json
+++ b/addons/pvr.hts/pvr.hts.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.hts",
-            "tag": "20.1.2-Nexus",
-            "commit": "c2fb65bf6fca28b061feef67afd83b0869fdfa00"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/pvr.hts/pvr.hts.json
+++ b/addons/pvr.hts/pvr.hts.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/kodi-pvr/pvr.hts",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/pvr.iptvsimple/pvr.iptvsimple.json
+++ b/addons/pvr.iptvsimple/pvr.iptvsimple.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.iptvsimple",
-            "tag": "20.1.2-Nexus",
-            "commit": "fb5df8cff8e6826f5b2e7a1b9ab34dc21e100011"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/pvr.iptvsimple/pvr.iptvsimple.json
+++ b/addons/pvr.iptvsimple/pvr.iptvsimple.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/kodi-pvr/pvr.iptvsimple",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/pvr.mediaportal.tvserver/pvr.mediaportal.tvserver.json
+++ b/addons/pvr.mediaportal.tvserver/pvr.mediaportal.tvserver.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/kodi-pvr/pvr.mediaportal.tvserver",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/pvr.mediaportal.tvserver/pvr.mediaportal.tvserver.json
+++ b/addons/pvr.mediaportal.tvserver/pvr.mediaportal.tvserver.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.mediaportal.tvserver",
-            "tag": "20.1.1-Nexus",
-            "commit": "dcdd6eb492b38878c2ee08447cee335e588077e4"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/pvr.mythtv/pvr.mythtv.json
+++ b/addons/pvr.mythtv/pvr.mythtv.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/janbar/pvr.mythtv",
-            "tag": "20.1.0-Nexus",
-            "commit": "0a40fcb52ce86de21e55310bbb5ae81b5731efff"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/pvr.mythtv/pvr.mythtv.json
+++ b/addons/pvr.mythtv/pvr.mythtv.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/janbar/pvr.mythtv",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/pvr.nextpvr/pvr.nextpvr.json
+++ b/addons/pvr.nextpvr/pvr.nextpvr.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/kodi-pvr/pvr.nextpvr",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/pvr.nextpvr/pvr.nextpvr.json
+++ b/addons/pvr.nextpvr/pvr.nextpvr.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.nextpvr",
-            "tag": "20.1.3-Nexus",
-            "commit": "f03c1ff4ed344a2732bcdd8f1e81eba7fad0af9c"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/pvr.njoy/pvr.njoy.json
+++ b/addons/pvr.njoy/pvr.njoy.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.njoy",
-            "tag": "20.1.0-Nexus",
-            "commit": "c18f4e38ebd455c64c951de08f577294c6d9e226"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/pvr.njoy/pvr.njoy.json
+++ b/addons/pvr.njoy/pvr.njoy.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/kodi-pvr/pvr.njoy",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/pvr.octonet/pvr.octonet.json
+++ b/addons/pvr.octonet/pvr.octonet.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/DigitalDevices/pvr.octonet",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/pvr.octonet/pvr.octonet.json
+++ b/addons/pvr.octonet/pvr.octonet.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/DigitalDevices/pvr.octonet",
-            "tag": "20.1.0-Nexus",
-            "commit": "fb17e25ef60a23471f7adc30fb688a351e7367d3"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/pvr.pctv/pvr.pctv.json
+++ b/addons/pvr.pctv/pvr.pctv.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/kodi-pvr/pvr.pctv",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/pvr.pctv/pvr.pctv.json
+++ b/addons/pvr.pctv/pvr.pctv.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.pctv",
-            "tag": "20.1.0-Nexus",
-            "commit": "6e7d848de557ae96504a18ac369d129d75f7d1f4"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/pvr.plutotv/pvr.plutotv.json
+++ b/addons/pvr.plutotv/pvr.plutotv.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/kodi-pvr/pvr.plutotv",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/pvr.plutotv/pvr.plutotv.json
+++ b/addons/pvr.plutotv/pvr.plutotv.json
@@ -1,0 +1,11 @@
+{
+    "name": "pvr.plutotv",
+    "buildsystem": "cmake-ninja",
+    "sources": [
+        {
+            "type": "git",
+            "url": "https://github.com/kodi-pvr/pvr.plutotv",
+            "branch": "Nexus"
+        }
+    ]
+}

--- a/addons/pvr.sledovanitv.cz/pvr.sledovanitv.cz.json
+++ b/addons/pvr.sledovanitv.cz/pvr.sledovanitv.cz.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/palinek/pvr.sledovanitv.cz",
-            "tag": "20.1.0-Nexus",
-            "commit": "c8a2ca64113a8d5db19d9cfaf89a890b5040532e"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/pvr.sledovanitv.cz/pvr.sledovanitv.cz.json
+++ b/addons/pvr.sledovanitv.cz/pvr.sledovanitv.cz.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/palinek/pvr.sledovanitv.cz",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/pvr.stalker/pvr.stalker.json
+++ b/addons/pvr.stalker/pvr.stalker.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/kodi-pvr/pvr.stalker",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/pvr.stalker/pvr.stalker.json
+++ b/addons/pvr.stalker/pvr.stalker.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.stalker",
-            "tag": "20.1.0-Nexus",
-            "commit": "6362331f97828babc6b57485a3c2c4cab2a98d7e"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/pvr.teleboy/pvr.teleboy.json
+++ b/addons/pvr.teleboy/pvr.teleboy.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/rbuehlma/pvr.teleboy",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/pvr.teleboy/pvr.teleboy.json
+++ b/addons/pvr.teleboy/pvr.teleboy.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/rbuehlma/pvr.teleboy",
-            "tag": "20.1.0-Nexus",
-            "commit": "3436337cd2ea64e90e63c98878e0bbdf9620c1c4"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/pvr.vbox/pvr.vbox.json
+++ b/addons/pvr.vbox/pvr.vbox.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.vbox",
-            "tag": "20.1.0-Nexus",
-            "commit": "fc895759ff632c07edfa39dd3e0fa6b03ef20dc4"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/pvr.vbox/pvr.vbox.json
+++ b/addons/pvr.vbox/pvr.vbox.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/kodi-pvr/pvr.vbox",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/pvr.vdr.vnsi/pvr.vdr.vnsi.json
+++ b/addons/pvr.vdr.vnsi/pvr.vdr.vnsi.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.vdr.vnsi",
-            "tag": "20.1.0-Nexus",
-            "commit": "e50b67f60bb8c5785f1666ed6ffdc9a1af9d19e1"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/pvr.vdr.vnsi/pvr.vdr.vnsi.json
+++ b/addons/pvr.vdr.vnsi/pvr.vdr.vnsi.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/kodi-pvr/pvr.vdr.vnsi",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/pvr.vuplus/pvr.vuplus.json
+++ b/addons/pvr.vuplus/pvr.vuplus.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/kodi-pvr/pvr.vuplus",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/pvr.vuplus/pvr.vuplus.json
+++ b/addons/pvr.vuplus/pvr.vuplus.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.vuplus",
-            "tag": "20.1.1-Nexus",
-            "commit": "7c1524e030540a393543beb1d92439c32a8547d8"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/pvr.waipu/pvr.waipu.json
+++ b/addons/pvr.waipu/pvr.waipu.json
@@ -1,0 +1,11 @@
+{
+    "name": "pvr.waipu",
+    "buildsystem": "cmake-ninja",
+    "sources": [
+        {
+            "type": "git",
+            "url": "https://github.com/flubshi/pvr.waipu",
+            "branch": "Nexus"
+        }
+    ]
+}

--- a/addons/pvr.waipu/pvr.waipu.json
+++ b/addons/pvr.waipu/pvr.waipu.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/flubshi/pvr.waipu",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/pvr.wmc/pvr.wmc.json
+++ b/addons/pvr.wmc/pvr.wmc.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/kodi-pvr/pvr.wmc",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/pvr.wmc/pvr.wmc.json
+++ b/addons/pvr.wmc/pvr.wmc.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.wmc",
-            "tag": "20.1.1-Nexus",
-            "commit": "401ce5e541957d1e14a11cc9f1272821df9591aa"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/pvr.zattoo/pvr.zattoo.json
+++ b/addons/pvr.zattoo/pvr.zattoo.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/rbuehlma/pvr.zattoo",
-            "tag": "20.1.0-Nexus",
-            "commit": "30744a562365924d2d36f84b8460893a28d21e4d"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/pvr.zattoo/pvr.zattoo.json
+++ b/addons/pvr.zattoo/pvr.zattoo.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/rbuehlma/pvr.zattoo",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/screensaver.asteroids/screensaver.asteroids.json
+++ b/addons/screensaver.asteroids/screensaver.asteroids.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/screensaver.asteroids",
-            "tag": "20.0.0-Nexus",
-            "commit": "9e0a94bf42c0d10e34c04b3f25fb5ec93b9f8129"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/screensaver.asteroids/screensaver.asteroids.json
+++ b/addons/screensaver.asteroids/screensaver.asteroids.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/screensaver.asteroids",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/screensaver.asterwave/screensaver.asterwave.json
+++ b/addons/screensaver.asterwave/screensaver.asterwave.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/screensaver.asterwave",
-            "tag": "20.0.0-Nexus",
-            "commit": "5313514aa151f58bd2a03aec68250c6aa3cea8ee"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/screensaver.asterwave/screensaver.asterwave.json
+++ b/addons/screensaver.asterwave/screensaver.asterwave.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/screensaver.asterwave",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/screensaver.biogenesis/screensaver.biogenesis.json
+++ b/addons/screensaver.biogenesis/screensaver.biogenesis.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/screensaver.biogenesis",
-            "tag": "20.0.0-Nexus",
-            "commit": "876199bad659fc34cf57942d2929c1704b4178be"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/screensaver.biogenesis/screensaver.biogenesis.json
+++ b/addons/screensaver.biogenesis/screensaver.biogenesis.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/screensaver.biogenesis",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/screensaver.cpblobs/screensaver.cpblobs.json
+++ b/addons/screensaver.cpblobs/screensaver.cpblobs.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/screensaver.cpblobs",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/screensaver.cpblobs/screensaver.cpblobs.json
+++ b/addons/screensaver.cpblobs/screensaver.cpblobs.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/screensaver.cpblobs",
-            "tag": "20.0.0-Nexus",
-            "commit": "92cc56f9e4e4da78d124596711d8fcf73cbdb148"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/screensaver.greynetic/screensaver.greynetic.json
+++ b/addons/screensaver.greynetic/screensaver.greynetic.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/screensaver.greynetic",
-            "tag": "20.0.0-Nexus",
-            "commit": "1e9854a31c6a0e7445246e262fdc8e9679e4e21f"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/screensaver.greynetic/screensaver.greynetic.json
+++ b/addons/screensaver.greynetic/screensaver.greynetic.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/screensaver.greynetic",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/screensaver.matrixtrails/screensaver.matrixtrails.json
+++ b/addons/screensaver.matrixtrails/screensaver.matrixtrails.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/screensaver.matrixtrails",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/screensaver.matrixtrails/screensaver.matrixtrails.json
+++ b/addons/screensaver.matrixtrails/screensaver.matrixtrails.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/screensaver.matrixtrails",
-            "tag": "20.0.0-Nexus",
-            "commit": "772b4e2e706e4d3091b899bc44d65db30635ed66"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/screensaver.pingpong/screensaver.pingpong.json
+++ b/addons/screensaver.pingpong/screensaver.pingpong.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/screensaver.pingpong",
-            "tag": "20.0.0-Nexus",
-            "commit": "9963fc67e0f2a79ae9bb67f123c32b795fd36893"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/screensaver.pingpong/screensaver.pingpong.json
+++ b/addons/screensaver.pingpong/screensaver.pingpong.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/screensaver.pingpong",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/screensaver.pyro/screensaver.pyro.json
+++ b/addons/screensaver.pyro/screensaver.pyro.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/screensaver.pyro",
-            "tag": "20.0.0-Nexus",
-            "commit": "3b58e45ecf50b86d64d3a1b2a712bb6843db5ed5"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/screensaver.pyro/screensaver.pyro.json
+++ b/addons/screensaver.pyro/screensaver.pyro.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/screensaver.pyro",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/screensaver.shadertoy/screensaver.shadertoy.json
+++ b/addons/screensaver.shadertoy/screensaver.shadertoy.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/screensaver.shadertoy",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/screensaver.shadertoy/screensaver.shadertoy.json
+++ b/addons/screensaver.shadertoy/screensaver.shadertoy.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/screensaver.shadertoy",
-            "tag": "20.0.0-Nexus",
-            "commit": "f4e0562a73e7b1373bbde03c9c1d22cd42c9c7d1"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/screensaver.stars/screensaver.stars.json
+++ b/addons/screensaver.stars/screensaver.stars.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/screensaver.stars",
-            "tag": "20.0.0-Nexus",
-            "commit": "1593563a53d97d1447e72c0ef55a3b24ac5e458a"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/screensaver.stars/screensaver.stars.json
+++ b/addons/screensaver.stars/screensaver.stars.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/screensaver.stars",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/screensavers.rsxs/screensavers.rsxs.json
+++ b/addons/screensavers.rsxs/screensavers.rsxs.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/screensavers.rsxs",
-            "tag": "20.0.1-Nexus",
-            "commit": "c2f83d373dca1f8ccdd164a7696b188ce2b1b855"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/screensavers.rsxs/screensavers.rsxs.json
+++ b/addons/screensavers.rsxs/screensavers.rsxs.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/screensavers.rsxs",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/vfs.libarchive/vfs.libarchive.json
+++ b/addons/vfs.libarchive/vfs.libarchive.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/vfs.libarchive",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/vfs.libarchive/vfs.libarchive.json
+++ b/addons/vfs.libarchive/vfs.libarchive.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/vfs.libarchive",
-            "tag": "20.0.0-Nexus",
-            "commit": "de850123ea379fe3fa671621f649751c7dcff860"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/vfs.rar/vfs.rar.json
+++ b/addons/vfs.rar/vfs.rar.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/vfs.rar",
-            "tag": "20.0.0-Nexus",
-            "commit": "9d4188e483ee9cb9b478be9b3d74d788239ee152"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/vfs.rar/vfs.rar.json
+++ b/addons/vfs.rar/vfs.rar.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/vfs.rar",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/vfs.sftp/vfs.sftp.json
+++ b/addons/vfs.sftp/vfs.sftp.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/vfs.sftp",
-            "tag": "20.0.0-Nexus",
-            "commit": "b5fb83e83cf477e0b20e3069f133521bd5e3ec02"
+            "branch": "Nexus"
         }
     ],
     "modules": [

--- a/addons/vfs.sftp/vfs.sftp.json
+++ b/addons/vfs.sftp/vfs.sftp.json
@@ -15,8 +15,14 @@
             "builddir": true,
             "config-opts": [
                 "-DWITH_GSSAPI=OFF",
-                "-DWITH_EXAMPLES=OFF"
+                "-DWITH_EXAMPLES=OFF",
+                "-DCMAKE_BUILD_TYPE=Release"
             ],
+            "build-options": {
+                "no-debuginfo": true,
+                "cflags": "-g0",
+                "cxxflags": "-g0"
+            },
             "sources": [
                 {
                     "type": "archive",
@@ -25,5 +31,13 @@
                 }
             ]
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/visualization.fishbmc/visualization.fishbmc.json
+++ b/addons/visualization.fishbmc/visualization.fishbmc.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/visualization.fishbmc",
-            "tag": "20.0.0-Nexus",
-            "commit": "183d5b6232a7d12beb5a696f783cd3514af93136"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/visualization.fishbmc/visualization.fishbmc.json
+++ b/addons/visualization.fishbmc/visualization.fishbmc.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/visualization.fishbmc",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/visualization.goom/visualization.goom.json
+++ b/addons/visualization.goom/visualization.goom.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/visualization.goom",
-            "tag": "20.0.0-Nexus",
-            "commit": "5c81f03e1e2e94b367f8df712b4c4df589ef1053"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/visualization.goom/visualization.goom.json
+++ b/addons/visualization.goom/visualization.goom.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/visualization.goom",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/visualization.matrix/visualization.matrix.json
+++ b/addons/visualization.matrix/visualization.matrix.json
@@ -1,0 +1,11 @@
+{
+    "name": "visualization.matrix",
+    "buildsystem": "cmake-ninja",
+    "sources": [
+        {
+            "type": "git",
+            "url": "https://github.com/xbmc/visualization.matrix",
+            "branch": "Nexus"
+        }
+    ]
+}

--- a/addons/visualization.matrix/visualization.matrix.json
+++ b/addons/visualization.matrix/visualization.matrix.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/visualization.matrix",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/visualization.pictureit/visualization.pictureit.json
+++ b/addons/visualization.pictureit/visualization.pictureit.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/visualization.pictureit",
-            "tag": "20.0.0-Nexus",
-            "commit": "d4361f228ae098ce1ab9ab5acdc5cb0e4c0ea13a"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/visualization.pictureit/visualization.pictureit.json
+++ b/addons/visualization.pictureit/visualization.pictureit.json
@@ -4,8 +4,16 @@
     "sources": [
         {
             "type": "git",
-            "url": "https://github.com/xbmc/visualization.pictureit",
+            "url": "https://github.com/linuxwhatelse/visualization.pictureit",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/visualization.projectm/visualization.projectm.json
+++ b/addons/visualization.projectm/visualization.projectm.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/visualization.projectm",
-            "tag": "20.0.1-Nexus",
-            "commit": "5fdc5278cb133ed98ae082a859261bf72445373c"
+            "branch": "Nexus"
         }
     ],
     "modules": [

--- a/addons/visualization.projectm/visualization.projectm.json
+++ b/addons/visualization.projectm/visualization.projectm.json
@@ -11,6 +11,11 @@
     "modules": [
         {
             "name": "projectm",
+            "build-options": {
+                "no-debuginfo": true,
+                "cflags": "-g0",
+                "cxxflags": "-g0"
+            },
             "sources": [
                 {
                     "type": "archive",
@@ -19,5 +24,13 @@
                 }
             ]
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/visualization.shadertoy/visualization.shadertoy.json
+++ b/addons/visualization.shadertoy/visualization.shadertoy.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/visualization.shadertoy",
-            "tag": "20.1.1-Nexus",
-            "commit": "6956b199e064face93ac38382b8ad18814254ba3"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/visualization.shadertoy/visualization.shadertoy.json
+++ b/addons/visualization.shadertoy/visualization.shadertoy.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/visualization.shadertoy",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/visualization.spectrum/visualization.spectrum.json
+++ b/addons/visualization.spectrum/visualization.spectrum.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/visualization.spectrum",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/visualization.spectrum/visualization.spectrum.json
+++ b/addons/visualization.spectrum/visualization.spectrum.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/visualization.spectrum",
-            "tag": "20.0.0-Nexus",
-            "commit": "4f9c4e8a5b015b213f9339e52f72712d92e167bd"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/visualization.starburst/visualization.starburst.json
+++ b/addons/visualization.starburst/visualization.starburst.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/visualization.starburst",
-            "tag": "20.0.0-Nexus",
-            "commit": "321464b1af21c6881486eddbefc98564b0ab8d83"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/visualization.starburst/visualization.starburst.json
+++ b/addons/visualization.starburst/visualization.starburst.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/visualization.starburst",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/addons/visualization.waveform/visualization.waveform.json
+++ b/addons/visualization.waveform/visualization.waveform.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/visualization.waveform",
-            "tag": "20.0.1-Nexus",
-            "commit": "64622d44012f7eaaf44fbc4e98a18c979ea8c85b"
+            "branch": "Nexus"
         }
     ]
 }

--- a/addons/visualization.waveform/visualization.waveform.json
+++ b/addons/visualization.waveform/visualization.waveform.json
@@ -7,5 +7,13 @@
             "url": "https://github.com/xbmc/visualization.waveform",
             "branch": "Nexus"
         }
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
     ]
 }

--- a/tools/addon_updater.py
+++ b/tools/addon_updater.py
@@ -1,0 +1,198 @@
+#!/usr/bin/python3
+
+import argparse
+import glob
+import json
+import os.path
+import pprint
+import shutil
+import sys
+
+import requests
+import tarfile
+
+addon_repo_base = 'https://github.com/xbmc/repo-binary-addons'
+addon_repo_branch = 'Nexus'
+addon_repo_dir = 'binary_addons_repo_tmp'
+addon_repo_remote = 'binary_addons_repo'
+
+
+def check_platform(def_file):
+    ret = False
+    platform_file = os.path.join(os.path.dirname(def_file), "platforms.txt")
+    with open(platform_file, mode='r') as plat_file:
+        platforms = plat_file.readline().split()
+        if args.verbose:
+            print("valid platforms for {}: {}".format(def_file, platforms))
+
+        if ('all' in platforms or 'linux' in platforms) and '!linux' not in platforms:
+            return True
+        for p in platforms:
+            if p.startswith('!') and p != '!linux':
+                ret = True
+        return ret
+
+
+def get_addon_definition(def_name, def_file) -> str:
+    if args.verbose:
+        print("get_addon_definition from", f)
+
+    if not check_platform(def_file):
+        raise Exception("platform mismatch")
+
+    with open(def_file, mode='r') as addon_def:
+        a_name, a_url, a_rev = addon_def.readline().split()
+        a_type = get_addon_type(a_url)
+
+    if a_name != def_name or a_type == 'unknown':
+        raise Exception("addon_definition_error")
+    if args.verbose:
+        print("found addon details - name: {}, url: {}, git_rev: {}, type: {}".format(a_name, a_url, a_rev, a_type))
+
+    if a_name != "" and a_url != "" and a_rev != "" and a_type != "":
+        return a_name, a_url, a_rev, a_type
+
+    raise Exception("addon_definition_error")
+
+
+def get_addon_type(addon_url) -> str:
+    if addon_url.endswith(('.tar.gz', '.tar.xz', '.tar.bz2', '.zip')):
+        return 'archive'
+    elif addon_url.startswith(('https://', 'http://')) or addon_url.endswith('.git'):
+        return 'git'
+
+    return 'unknown'
+
+
+def set_build_type(a_data):
+    if 'build-options' not in a_data:
+        a_data['build-options'] = {}
+    if 'config-opts' not in a_data:
+        a_data['config-opts'] = []
+    if args.release:
+        if "-DCMAKE_BUILD_TYPE=Release" not in a_data['config-opts']:
+            a_data['config-opts'].append("-DCMAKE_BUILD_TYPE=Release")
+        a_data['build-options']['no-debuginfo'] = True
+        a_data['build-options']['cflags'] = '-g0'
+        a_data['build-options']['cxxflags'] = '-g0'
+    else:
+        if "-DCMAKE_BUILD_TYPE=Release" in a_data['config-opts']:
+            a_data['config-opts'].remove("-DCMAKE_BUILD_TYPE=Release")
+        a_data['build-options']['no-debuginfo'] = False
+        a_data['build-options']['cflags'] = a_data['build-options']['cflags'].replace('-g0', '')
+        a_data['build-options']['cxxflags'] = a_data['build-options']['cxxflags'].replace('-g0', '')
+        if a_data['build-options']['cflags'].strip() == "":
+            del (a_data['build-options']['cflags'])
+        if a_data['build-options']['cxxflags'].strip() == "":
+            del (a_data['build-options']['cxxflags'])
+
+    return a_data
+
+
+def update_addon_repo():
+    if args.verbose:
+        print("downloading binary addon repo")
+
+    if os.path.isdir(addon_repo_dir):
+        shutil.rmtree(addon_repo_dir)
+    addon_repo_url = addon_repo_base + '/archive/refs/heads/' + addon_repo_branch + '.tar.gz'
+    response = requests.get(addon_repo_url, stream=True)
+    try:
+        with tarfile.open(fileobj=response.raw, mode='r|gz') as tarball:
+            tarball.extractall(addon_repo_dir)
+    except tarfile.ReadError as e:
+        print("Error downloading repository tarball {}, did you specify an existing branch from {}?".format(
+            addon_repo_url, addon_repo_base))
+        sys.exit(2)
+
+
+### Main ###
+pp = pprint.PrettyPrinter(indent=4)
+parser = argparse.ArgumentParser()
+parser.add_argument("-u", "--update_repo", help="force updating binary addons repo", action="store_true")
+parser.add_argument("-v", "--verbose", help="enable verbose output", action="store_true")
+parser.add_argument("-b", "--branch", help="override repo branch (default: {})".format(addon_repo_branch))
+parser.add_argument("-r", "--release", help="enable release builds", action="store_true")
+args = parser.parse_args()
+
+if args.branch:
+    addon_repo_branch = args.branch
+
+if args.update_repo or not os.path.isdir(addon_repo_dir):
+    update_addon_repo()
+
+# find all available addons in repo
+repo_file_list = glob.glob(addon_repo_dir + '/*-' + addon_repo_branch + '/*/*.txt', recursive=True)
+if len(repo_file_list) == 0:
+    print("Warning: couldn't find any repository files, forcing repo update")
+    update_addon_repo()
+    repo_file_list = glob.glob(addon_repo_dir + '/*-' + addon_repo_branch + '/*/*.txt', recursive=True)
+
+if args.verbose:
+    print("{}: {}".format("addon_files", repo_file_list))
+
+skipped_addons = {}
+missing_addons = []
+
+for f in repo_file_list:
+    definition_file = os.path.basename(f)
+    if definition_file == 'platforms.txt':
+        continue
+
+    try:
+        addon_id = definition_file.rsplit('.txt', maxsplit=1)[0]
+        (name, url, rev, atype) = get_addon_definition(addon_id, f)
+    except Exception as e:
+        print("Error parsing addon definition in {}: {} - skipping".format(definition_file, e))
+        skipped_addons[addon_id] = e.__str__()
+        continue
+
+    addon_json = os.path.join('../addons/', addon_id, addon_id + '.json')
+
+    if not os.path.exists(addon_json):
+        skipped_addons[addon_id] = "not found in existing flatpak addons"
+        missing_addons.append(addon_id)
+        continue
+
+    print("updating", addon_id)
+
+    # parse and update manifests
+    with open(addon_json, mode='r+') as jf:
+        addon_data = json.load(jf)
+        if args.verbose:
+            print(addon_data)
+
+        if addon_data['name'] != name:
+            print("Error: skipping addon due to name mismatch: {} vs {}".format(name, addon_data['name']))
+            skipped_addons[addon_id] = "name mismatch: {} vs {}".format(name, addon_data['name'])
+            continue
+
+        addon_data = set_build_type(addon_data)
+
+        i = 0
+        while i < len(addon_data['sources']) and addon_data['sources'][i]['type'] not in ["git", "archive"]:
+            i = i + 1
+
+        addon_data['sources'][i]['url'] = url
+        addon_data['sources'][i]['type'] = atype
+
+        if addon_repo_branch == rev or rev == 'master':
+            addon_data['sources'][i]['branch'] = rev
+            if 'commit' in addon_data['sources'][i]:
+                del (addon_data['sources'][i]['commit'])
+        else:
+            addon_data['sources'][i]['commit'] = rev
+
+        if 'tag' in addon_data['sources'][i]:
+            del (addon_data['sources'][i]['tag'])
+
+        # save file
+        jf.seek(0)
+        jf.write(json.dumps(addon_data, indent=4))
+        jf.write('\n')
+        jf.truncate()
+
+print("\n\n### DONE ###\nskipped addons:")
+pp.pprint(skipped_addons)
+print("\nmissing addons:")
+pp.pprint(missing_addons)

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -114,7 +114,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/xbmc/xbmc.git
-        commit: 1b1e86a672b0e502506f29e7fb31a7aaadbc4dbe
+        commit: 918ff46a659fc12502e42cd7db62eaf250e07493
       - type: patch
         path: kodi.sh.in.patch
       - type: file

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -204,6 +204,7 @@ modules:
   - addons/pvr.vbox/pvr.vbox.json
   - addons/pvr.vdr.vnsi/pvr.vdr.vnsi.json
   - addons/pvr.vuplus/pvr.vuplus.json
+  - addons/pvr.waipu/pvr.waipu.json
   - addons/pvr.wmc/pvr.wmc.json
   - addons/pvr.zattoo/pvr.zattoo.json
   - addons/screensaver.asteroids/screensaver.asteroids.json

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -197,6 +197,7 @@ modules:
   - addons/pvr.njoy/pvr.njoy.json
   - addons/pvr.octonet/pvr.octonet.json
   - addons/pvr.pctv/pvr.pctv.json
+  - addons/pvr.plutotv/pvr.plutotv.json
   - addons/pvr.sledovanitv.cz/pvr.sledovanitv.cz.json
   - addons/pvr.stalker/pvr.stalker.json
   - addons/pvr.teleboy/pvr.teleboy.json

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -220,6 +220,7 @@ modules:
   - addons/vfs.sftp/vfs.sftp.json
   - addons/visualization.fishbmc/visualization.fishbmc.json
   - addons/visualization.goom/visualization.goom.json
+  - addons/visualization.matrix/visualization.matrix.json
   - addons/visualization.pictureit/visualization.pictureit.json
   - addons/visualization.projectm/visualization.projectm.json
   - addons/visualization.shadertoy/visualization.shadertoy.json

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -151,6 +151,7 @@ modules:
   - addons/audiodecoder.fluidsynth/audiodecoder.fluidsynth.json
   - addons/audiodecoder.gme/audiodecoder.gme.json
   - addons/audiodecoder.gsf/audiodecoder.gsf.json
+  - addons/audiodecoder.hvl/audiodecoder.hvl.json
   - addons/audiodecoder.modplug/audiodecoder.modplug.json
   - addons/audiodecoder.ncsf/audiodecoder.ncsf.json
   - addons/audiodecoder.nosefart/audiodecoder.nosefart.json


### PR DESCRIPTION
- add a script to change addon manifests to the definition from our binary addon repo.
  this removes specifics like git tag and git commit since upstream usually only defines the branch.
- greatly reduces work in order to update addons
  every build will automatically use up to date addons, manual work is only needed if dependecies or build flags change

I've also added 2 missing addons: pvr.plutotv and visualization.matrix
