### PR TITLE
Patch crashlog dir

### DIFF
--- a/kodi.sh.in.patch
+++ b/kodi.sh.in.patch
@@ -1,12 +1,14 @@
---- xbmc-19.0-Matrix/tools/Linux/kodi.sh.in-	2021-02-18 23:17:59.000000000 +0100
-+++ xbmc-19.0-Matrix/tools/Linux/kodi.sh.in	2021-02-26 19:41:34.096224586 +0100
-@@ -27,7 +27,8 @@
+--- a/tools/Linux/kodi.sh.in
++++ b/tools/Linux/kodi.sh.in
+@@ -26,8 +26,9 @@ exec_prefix="@exec_prefix@"
+ datarootdir="@datarootdir@"
  LIBDIR="@libdir@"
  APP_BINARY=$LIBDIR/${bin_name}/@APP_BINARY@
- CRASHLOG_DIR=${CRASHLOG_DIR:-$HOME}
+-CRASHLOG_DIR=${CRASHLOG_DIR:-$HOME}
 -KODI_DATA=${KODI_DATA:-"${HOME}/.${bin_name}"} # mapped to special://home/
++export CRASHLOG_DIR=${XDG_DATA_HOME}
 +export KODI_DATA=${XDG_DATA_HOME}
 +export KODI_HOME=/app/share/kodi
-
+ 
  # Workaround for high CPU load with nvidia GFX
  export __GL_YIELD=USLEEP


### PR DESCRIPTION
Otherwise the crashlog will be written to the host folder, which we
usually don't expose in the flatpak (for good reasons).
This means, that it won't be written.