### PR TITLE
don't enable pvr addons automatically

### DIFF
--- a/addon-manifest.xml.patch
+++ b/addon-manifest.xml.patch
@@ -1,6 +1,6 @@
 --- a/system/addon-manifest.xml
 +++ b/system/addon-manifest.xml
-@@ -58,4 +58,86 @@
+@@ -58,4 +58,61 @@
    <addon>xbmc.webinterface</addon>
    <addon optional="true">peripheral.joystick</addon>
    <addon optional="true">inputstream.adaptive</addon>
@@ -38,31 +38,6 @@
 +  <addon optional="true">inputstream.ffmpegdirect</addon>
 +  <addon optional="true">inputstream.rtmp</addon>
 +  <addon optional="true">peripheral.xarcade</addon>
-+  <addon optional="true">pvr.argustv</addon>
-+  <addon optional="true">pvr.demo</addon>
-+  <addon optional="true">pvr.dvblink</addon>
-+  <addon optional="true">pvr.dvbviewer</addon>
-+  <addon optional="true">pvr.filmon</addon>
-+  <addon optional="true">pvr.freebox</addon>
-+  <addon optional="true">pvr.hdhomerun</addon>
-+  <addon optional="true">pvr.hts</addon>
-+  <addon optional="true">pvr.iptvsimple</addon>
-+  <addon optional="true">pvr.mediaportal.tvserver</addon>
-+  <addon optional="true">pvr.mythtv</addon>
-+  <addon optional="true">pvr.nextpvr</addon>
-+  <addon optional="true">pvr.njoy</addon>
-+  <addon optional="true">pvr.octonet</addon>
-+  <addon optional="true">pvr.pctv</addon>
-+  <addon optional="true">pvr.plutotv</addon>
-+  <addon optional="true">pvr.sledovanitv.cz</addon>
-+  <addon optional="true">pvr.stalker</addon>
-+  <addon optional="true">pvr.teleboy</addon>
-+  <addon optional="true">pvr.vbox</addon>
-+  <addon optional="true">pvr.vdr.vnsi</addon>
-+  <addon optional="true">pvr.vuplus</addon>
-+  <addon optional="true">pvr.wmc</addon>
-+  <addon optional="true">pvr.waipu</addon>
-+  <addon optional="true">pvr.zattoo</addon>
 +  <addon optional="true">screensaver.asteroids</addon>
 +  <addon optional="true">screensaver.asterwave</addon>
 +  <addon optional="true">screensaver.biogenesis</addon>

--- a/addons-no-startupenable.patch
+++ b/addons-no-startupenable.patch
@@ -1,0 +1,13 @@
+diff --git a/xbmc/platform/linux/PlatformLinux.h b/xbmc/platform/linux/PlatformLinux.h
+index c45d41143a..9a872a5f55 100644
+--- a/xbmc/platform/linux/PlatformLinux.h
++++ b/xbmc/platform/linux/PlatformLinux.h
+@@ -21,7 +21,6 @@ public:
+   ~CPlatformLinux() override = default;
+ 
+   bool Init() override;
+-  bool IsConfigureAddonsAtStartupEnabled() override { return true; };
+ 
+ private:
+   std::unique_ptr<OPTIONALS::CLircContainer, OPTIONALS::delete_CLircContainer> m_lirc;
+

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -119,6 +119,8 @@ modules:
         path: kodi.sh.in.patch
       - type: patch
         path: addon-manifest.xml.patch
+      - type: patch
+        path: addons-no-startupenable.patch
       - type: file
         url: http://mirrors.kodi.tv/build-deps/sources/crossguid-8f399e8bd4.tar.gz
         sha256: 3d77d09a5df0de510aeeb940df4cb534787ddff3bb1828779753f5dfa1229d10


### PR DESCRIPTION
enabling pvr addons by default causes crashing with a clean user data dir.

also see https://forum.kodi.tv/showthread.php?tid=366614