### PR TITLE
Reenable fishbmc

### DIFF
--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -234,7 +234,7 @@ modules:
   - addons/vfs.libarchive/vfs.libarchive.json
   - addons/vfs.rar/vfs.rar.json
   - addons/vfs.sftp/vfs.sftp.json
-  # - addons/visualization.fishbmc/visualization.fishbmc.json
+  - addons/visualization.fishbmc/visualization.fishbmc.json
   - addons/visualization.goom/visualization.goom.json
   - addons/visualization.matrix/visualization.matrix.json
   - addons/visualization.pictureit/visualization.pictureit.json


### PR DESCRIPTION
This is a reminder to reenable fishbmc when https://github.com/xbmc/visualization.fishbmc/pull/55 is merged