### PR TITLE
Split out debug symbols again

### DIFF
--- a/addons/audiodecoder.2sf/audiodecoder.2sf.json
+++ b/addons/audiodecoder.2sf/audiodecoder.2sf.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/audiodecoder.asap/audiodecoder.asap.json
+++ b/addons/audiodecoder.asap/audiodecoder.asap.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/audiodecoder.dumb/audiodecoder.dumb.json
+++ b/addons/audiodecoder.dumb/audiodecoder.dumb.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/audiodecoder.fluidsynth/audiodecoder.fluidsynth.json
+++ b/addons/audiodecoder.fluidsynth/audiodecoder.fluidsynth.json
@@ -2,12 +2,11 @@
     "name": "audiodecoder.fluidsynth",
     "buildsystem": "cmake-ninja",
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },
     "config-opts": [
-         "-DCMAKE_BUILD_TYPE=Release"
+        "-DCMAKE_BUILD_TYPE=Release"
     ],
     "sources": [
         {
@@ -25,7 +24,6 @@
                 "-DLIB_SUFFIX="
             ],
             "build-options": {
-                "no-debuginfo": true,
                 "cflags": "-g0",
                 "cxxflags": "-g0"
             },

--- a/addons/audiodecoder.gme/audiodecoder.gme.json
+++ b/addons/audiodecoder.gme/audiodecoder.gme.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/audiodecoder.gsf/audiodecoder.gsf.json
+++ b/addons/audiodecoder.gsf/audiodecoder.gsf.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/audiodecoder.hvl/audiodecoder.hvl.json
+++ b/addons/audiodecoder.hvl/audiodecoder.hvl.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/audiodecoder.modplug/audiodecoder.modplug.json
+++ b/addons/audiodecoder.modplug/audiodecoder.modplug.json
@@ -17,7 +17,6 @@
                 "-DCMAKE_BUILD_TYPE=Release"
             ],
             "build-options": {
-                "no-debuginfo": true,
                 "cflags": "-g0",
                 "cxxflags": "-g0"
             },
@@ -31,7 +30,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/audiodecoder.ncsf/audiodecoder.ncsf.json
+++ b/addons/audiodecoder.ncsf/audiodecoder.ncsf.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/audiodecoder.nosefart/audiodecoder.nosefart.json
+++ b/addons/audiodecoder.nosefart/audiodecoder.nosefart.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/audiodecoder.openmpt/audiodecoder.openmpt.json
+++ b/addons/audiodecoder.openmpt/audiodecoder.openmpt.json
@@ -17,7 +17,6 @@
                 "--disable-tests"
             ],
             "build-options": {
-                "no-debuginfo": true,
                 "cflags": "-g0",
                 "cxxflags": "-g0"
             },
@@ -34,7 +33,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/audiodecoder.organya/audiodecoder.organya.json
+++ b/addons/audiodecoder.organya/audiodecoder.organya.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/audiodecoder.qsf/audiodecoder.qsf.json
+++ b/addons/audiodecoder.qsf/audiodecoder.qsf.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/audiodecoder.sacd/audiodecoder.sacd.json
+++ b/addons/audiodecoder.sacd/audiodecoder.sacd.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/audiodecoder.sidplay/audiodecoder.sidplay.json
+++ b/addons/audiodecoder.sidplay/audiodecoder.sidplay.json
@@ -13,7 +13,6 @@
             "name": "sidplay2",
             "buildsystem": "autotools",
             "build-options": {
-                "no-debuginfo": true,
                 "cflags": "-g0",
                 "cxxflags": "-g0"
             },
@@ -59,7 +58,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/audiodecoder.snesapu/audiodecoder.snesapu.json
+++ b/addons/audiodecoder.snesapu/audiodecoder.snesapu.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/audiodecoder.ssf/audiodecoder.ssf.json
+++ b/addons/audiodecoder.ssf/audiodecoder.ssf.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/audiodecoder.stsound/audiodecoder.stsound.json
+++ b/addons/audiodecoder.stsound/audiodecoder.stsound.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/audiodecoder.timidity/audiodecoder.timidity.json
+++ b/addons/audiodecoder.timidity/audiodecoder.timidity.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/audiodecoder.upse/audiodecoder.upse.json
+++ b/addons/audiodecoder.upse/audiodecoder.upse.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/audiodecoder.usf/audiodecoder.usf.json
+++ b/addons/audiodecoder.usf/audiodecoder.usf.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/audiodecoder.vgmstream/audiodecoder.vgmstream.json
+++ b/addons/audiodecoder.vgmstream/audiodecoder.vgmstream.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/audiodecoder.wsr/audiodecoder.wsr.json
+++ b/addons/audiodecoder.wsr/audiodecoder.wsr.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/audioencoder.flac/audioencoder.flac.json
+++ b/addons/audioencoder.flac/audioencoder.flac.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/audioencoder.lame/audioencoder.lame.json
+++ b/addons/audioencoder.lame/audioencoder.lame.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/audioencoder.vorbis/audioencoder.vorbis.json
+++ b/addons/audioencoder.vorbis/audioencoder.vorbis.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/audioencoder.wav/audioencoder.wav.json
+++ b/addons/audioencoder.wav/audioencoder.wav.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/game.libretro.2048/game.libretro.2048.json
+++ b/addons/game.libretro.2048/game.libretro.2048.json
@@ -21,7 +21,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/game.libretro.mrboom/game.libretro.mrboom.json
+++ b/addons/game.libretro.mrboom/game.libretro.mrboom.json
@@ -2,7 +2,6 @@
     "name": "game.libretro.mrboom",
     "buildsystem": "cmake-ninja",
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },
@@ -22,7 +21,6 @@
             "name": "mrboom",
             "buildsystem": "simple",
             "build-options": {
-                "no-debuginfo": true,
                 "cflags": "-g0",
                 "cxxflags": "-g0"
             },

--- a/addons/game.libretro/game.libretro.json
+++ b/addons/game.libretro/game.libretro.json
@@ -1,69 +1,66 @@
 {
-    "name": "game.libretro",
-    "buildsystem": "cmake-ninja",
-    "build-options": {
-        "no-debuginfo": true,
-        "cflags": "-g0",
-        "cxxflags": "-g0"
-    },
-    "config-opts": [
-        "-DCMAKE_BUILD_TYPE=Release"
-    ],
-    "cleanup": [
-        "/include",
-        "*.a",
-        "*.la"
-    ],
-    "sources": [
+  "name": "game.libretro",
+  "buildsystem": "cmake-ninja",
+  "build-options": {
+    "cflags": "-g0 -fPIC",
+    "cxxflags": "-g0 -fPIC"
+  },
+  "config-opts": [
+    "-DCMAKE_BUILD_TYPE=Release"
+  ],
+  "cleanup": [
+    "/include",
+    "*.a",
+    "*.la"
+  ],
+  "sources": [
+    {
+      "type": "git",
+      "url": "https://github.com/kodi-game/game.libretro",
+      "branch": "Nexus"
+    }
+  ],
+  "modules": [
+    "../../modules/tinyxml/tinyxml.json",
+    {
+      "name": "libretro-common",
+      "buildsystem": "cmake-ninja",
+      "build-options": {
+        "cflags": "-g0 -fPIC",
+        "cxxflags": "-g0 -fPIC"
+      },
+      "sources": [
         {
-            "type": "git",
-            "url": "https://github.com/kodi-game/game.libretro",
-            "branch": "Nexus"
-        }
-    ],
-    "modules": [
-        "../../modules/tinyxml/tinyxml.json",
-        {
-            "name": "libretro-common",
-            "buildsystem": "cmake-ninja",
-            "build-options": {
-                "no-debuginfo": true,
-                "cflags": "-g0 -fPIC",
-                "cxxflags": "-g0 -fPIC"
-            },
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://github.com/libretro/libretro-common/archive/50c15a88eb741cbe675743a282d8cc4c89421e3f.tar.gz",
-                    "sha256": "042986fad22dc37188df7a186d17a258edfe8e552353f9b509a47418e8dfa623"
-                },
-                {
-                    "type": "file",
-                    "url": "https://raw.githubusercontent.com/kodi-game/game.libretro/Nexus/depends/common/libretro-common/CMakeLists.txt",
-                    "sha256": "fe0698a56bf869f8c6af2cbd0cc3dc9c05c370141009fa4777373538c1a41af1"
-                }
-            ]
+          "type": "archive",
+          "url": "https://github.com/libretro/libretro-common/archive/50c15a88eb741cbe675743a282d8cc4c89421e3f.tar.gz",
+          "sha256": "042986fad22dc37188df7a186d17a258edfe8e552353f9b509a47418e8dfa623"
         },
         {
-            "name": "rcheevos",
-            "buildsystem": "cmake-ninja",
-            "build-options": {
-                "no-debuginfo": true,
-                "cflags": "-g0 -fPIC",
-                "cxxflags": "-g0 -fPIC"
-            },
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://github.com/RetroAchievements/rcheevos/archive/v9.2.0.tar.gz",
-                    "sha256": "c8ed6ca74f905ea0c256250e46cced579922880001337e7c3d3d68179ad89d4e"
-                },
-                {
-                    "type": "file",
-                    "url": "https://raw.githubusercontent.com/kodi-game/game.libretro/Nexus/depends/common/rcheevos/CMakeLists.txt",
-                    "sha256": "33662a2bfff8a17d7707c5b8a0239bb00d559302975e7b9b7e0eac1f2e6c10c5"
-                }
-            ]
+          "type": "file",
+          "url": "https://raw.githubusercontent.com/kodi-game/game.libretro/Nexus/depends/common/libretro-common/CMakeLists.txt",
+          "sha256": "fe0698a56bf869f8c6af2cbd0cc3dc9c05c370141009fa4777373538c1a41af1"
         }
-    ]
+      ]
+    },
+    {
+      "name": "rcheevos",
+      "buildsystem": "cmake-ninja",
+      "build-options": {
+        "cflags": "-g0 -fPIC",
+        "cxxflags": "-g0 -fPIC"
+      },
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/RetroAchievements/rcheevos/archive/v9.2.0.tar.gz",
+          "sha256": "c8ed6ca74f905ea0c256250e46cced579922880001337e7c3d3d68179ad89d4e"
+        },
+        {
+          "type": "file",
+          "url": "https://raw.githubusercontent.com/kodi-game/game.libretro/Nexus/depends/common/rcheevos/CMakeLists.txt",
+          "sha256": "33662a2bfff8a17d7707c5b8a0239bb00d559302975e7b9b7e0eac1f2e6c10c5"
+        }
+      ]
+    }
+  ]
 }

--- a/addons/imagedecoder.heif/imagedecoder.heif.json
+++ b/addons/imagedecoder.heif/imagedecoder.heif.json
@@ -21,7 +21,6 @@
                 "-DWITH_DAV1D=0"
             ],
             "build-options": {
-                "no-debuginfo": true,
                 "cflags": "-g0",
                 "cxxflags": "-g0"
             },
@@ -37,7 +36,6 @@
             "name": "libde265",
             "buildsystem": "cmake-ninja",
             "build-options": {
-                "no-debuginfo": true,
                 "cflags": "-g0",
                 "cxxflags": "-g0"
             },
@@ -51,7 +49,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/imagedecoder.mpo/imagedecoder.mpo.json
+++ b/addons/imagedecoder.mpo/imagedecoder.mpo.json
@@ -10,7 +10,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/imagedecoder.raw/imagedecoder.raw.json
+++ b/addons/imagedecoder.raw/imagedecoder.raw.json
@@ -12,7 +12,6 @@
         {
             "name": "libraw",
             "build-options": {
-                "no-debuginfo": true,
                 "cflags": "-g0",
                 "cxxflags": "-g0"
             },
@@ -33,7 +32,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/inputstream.adaptive/inputstream.adaptive.json
+++ b/addons/inputstream.adaptive/inputstream.adaptive.json
@@ -21,7 +21,6 @@
     }
   ],
   "build-options": {
-    "no-debuginfo": true,
     "cflags": "-g0",
     "cxxflags": "-g0"
   }

--- a/addons/inputstream.ffmpegdirect/inputstream.ffmpegdirect.json
+++ b/addons/inputstream.ffmpegdirect/inputstream.ffmpegdirect.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/inputstream.rtmp/inputstream.rtmp.json
+++ b/addons/inputstream.rtmp/inputstream.rtmp.json
@@ -19,7 +19,6 @@
                 "make -C librtmp install PREFIX=/app"
             ],
             "build-options": {
-                "no-debuginfo": true,
                 "cflags": "-g0",
                 "cxxflags": "-g0"
             },
@@ -33,7 +32,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/peripheral.joystick/peripheral.joystick.json
+++ b/addons/peripheral.joystick/peripheral.joystick.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/peripheral.xarcade/peripheral.xarcade.json
+++ b/addons/peripheral.xarcade/peripheral.xarcade.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/pvr.argustv/pvr.argustv.json
+++ b/addons/pvr.argustv/pvr.argustv.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/pvr.demo/pvr.demo.json
+++ b/addons/pvr.demo/pvr.demo.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/pvr.dvblink/pvr.dvblink.json
+++ b/addons/pvr.dvblink/pvr.dvblink.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/pvr.dvbviewer/pvr.dvbviewer.json
+++ b/addons/pvr.dvbviewer/pvr.dvbviewer.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/pvr.filmon/pvr.filmon.json
+++ b/addons/pvr.filmon/pvr.filmon.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/pvr.freebox/pvr.freebox.json
+++ b/addons/pvr.freebox/pvr.freebox.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/pvr.hdhomerun/pvr.hdhomerun.json
+++ b/addons/pvr.hdhomerun/pvr.hdhomerun.json
@@ -13,7 +13,6 @@
             "name": "libhdhomerun",
             "buildsystem": "cmake-ninja",
             "build-options": {
-                "no-debuginfo": true,
                 "cflags": "-g0",
                 "cxxflags": "-g0"
             },
@@ -34,7 +33,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/pvr.hts/pvr.hts.json
+++ b/addons/pvr.hts/pvr.hts.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/pvr.iptvsimple/pvr.iptvsimple.json
+++ b/addons/pvr.iptvsimple/pvr.iptvsimple.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/pvr.mediaportal.tvserver/pvr.mediaportal.tvserver.json
+++ b/addons/pvr.mediaportal.tvserver/pvr.mediaportal.tvserver.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/pvr.mythtv/pvr.mythtv.json
+++ b/addons/pvr.mythtv/pvr.mythtv.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/pvr.nextpvr/pvr.nextpvr.json
+++ b/addons/pvr.nextpvr/pvr.nextpvr.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/pvr.njoy/pvr.njoy.json
+++ b/addons/pvr.njoy/pvr.njoy.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/pvr.octonet/pvr.octonet.json
+++ b/addons/pvr.octonet/pvr.octonet.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/pvr.pctv/pvr.pctv.json
+++ b/addons/pvr.pctv/pvr.pctv.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/pvr.plutotv/pvr.plutotv.json
+++ b/addons/pvr.plutotv/pvr.plutotv.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/pvr.sledovanitv.cz/pvr.sledovanitv.cz.json
+++ b/addons/pvr.sledovanitv.cz/pvr.sledovanitv.cz.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/pvr.stalker/pvr.stalker.json
+++ b/addons/pvr.stalker/pvr.stalker.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/pvr.teleboy/pvr.teleboy.json
+++ b/addons/pvr.teleboy/pvr.teleboy.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/pvr.vbox/pvr.vbox.json
+++ b/addons/pvr.vbox/pvr.vbox.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/pvr.vdr.vnsi/pvr.vdr.vnsi.json
+++ b/addons/pvr.vdr.vnsi/pvr.vdr.vnsi.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/pvr.vuplus/pvr.vuplus.json
+++ b/addons/pvr.vuplus/pvr.vuplus.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/pvr.waipu/pvr.waipu.json
+++ b/addons/pvr.waipu/pvr.waipu.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/pvr.wmc/pvr.wmc.json
+++ b/addons/pvr.wmc/pvr.wmc.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/pvr.zattoo/pvr.zattoo.json
+++ b/addons/pvr.zattoo/pvr.zattoo.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/screensaver.asteroids/screensaver.asteroids.json
+++ b/addons/screensaver.asteroids/screensaver.asteroids.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/screensaver.asterwave/screensaver.asterwave.json
+++ b/addons/screensaver.asterwave/screensaver.asterwave.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/screensaver.biogenesis/screensaver.biogenesis.json
+++ b/addons/screensaver.biogenesis/screensaver.biogenesis.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/screensaver.cpblobs/screensaver.cpblobs.json
+++ b/addons/screensaver.cpblobs/screensaver.cpblobs.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/screensaver.greynetic/screensaver.greynetic.json
+++ b/addons/screensaver.greynetic/screensaver.greynetic.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/screensaver.matrixtrails/screensaver.matrixtrails.json
+++ b/addons/screensaver.matrixtrails/screensaver.matrixtrails.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/screensaver.pingpong/screensaver.pingpong.json
+++ b/addons/screensaver.pingpong/screensaver.pingpong.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/screensaver.pyro/screensaver.pyro.json
+++ b/addons/screensaver.pyro/screensaver.pyro.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/screensaver.shadertoy/screensaver.shadertoy.json
+++ b/addons/screensaver.shadertoy/screensaver.shadertoy.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/screensaver.stars/screensaver.stars.json
+++ b/addons/screensaver.stars/screensaver.stars.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/screensavers.rsxs/screensavers.rsxs.json
+++ b/addons/screensavers.rsxs/screensavers.rsxs.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/vfs.libarchive/vfs.libarchive.json
+++ b/addons/vfs.libarchive/vfs.libarchive.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/vfs.rar/vfs.rar.json
+++ b/addons/vfs.rar/vfs.rar.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/vfs.sftp/vfs.sftp.json
+++ b/addons/vfs.sftp/vfs.sftp.json
@@ -19,7 +19,6 @@
                 "-DCMAKE_BUILD_TYPE=Release"
             ],
             "build-options": {
-                "no-debuginfo": true,
                 "cflags": "-g0",
                 "cxxflags": "-g0"
             },
@@ -33,7 +32,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/visualization.fishbmc/visualization.fishbmc.json
+++ b/addons/visualization.fishbmc/visualization.fishbmc.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/visualization.goom/visualization.goom.json
+++ b/addons/visualization.goom/visualization.goom.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/visualization.matrix/visualization.matrix.json
+++ b/addons/visualization.matrix/visualization.matrix.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/visualization.pictureit/visualization.pictureit.json
+++ b/addons/visualization.pictureit/visualization.pictureit.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/visualization.projectm/visualization.projectm.json
+++ b/addons/visualization.projectm/visualization.projectm.json
@@ -12,7 +12,6 @@
         {
             "name": "projectm",
             "build-options": {
-                "no-debuginfo": true,
                 "cflags": "-g0",
                 "cxxflags": "-g0"
             },
@@ -26,7 +25,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/visualization.shadertoy/visualization.shadertoy.json
+++ b/addons/visualization.shadertoy/visualization.shadertoy.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/visualization.spectrum/visualization.spectrum.json
+++ b/addons/visualization.spectrum/visualization.spectrum.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/visualization.starburst/visualization.starburst.json
+++ b/addons/visualization.starburst/visualization.starburst.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/addons/visualization.waveform/visualization.waveform.json
+++ b/addons/visualization.waveform/visualization.waveform.json
@@ -9,7 +9,6 @@
         }
     ],
     "build-options": {
-        "no-debuginfo": true,
         "cflags": "-g0",
         "cxxflags": "-g0"
     },

--- a/tools/addon_updater.py
+++ b/tools/addon_updater.py
@@ -72,19 +72,20 @@ def set_build_type(a_data):
     if args.release:
         if "-DCMAKE_BUILD_TYPE=Release" not in a_data['config-opts']:
             a_data['config-opts'].append("-DCMAKE_BUILD_TYPE=Release")
-        a_data['build-options']['no-debuginfo'] = True
         a_data['build-options']['cflags'] = '-g0'
         a_data['build-options']['cxxflags'] = '-g0'
     else:
         if "-DCMAKE_BUILD_TYPE=Release" in a_data['config-opts']:
             a_data['config-opts'].remove("-DCMAKE_BUILD_TYPE=Release")
-        a_data['build-options']['no-debuginfo'] = False
         a_data['build-options']['cflags'] = a_data['build-options']['cflags'].replace('-g0', '')
         a_data['build-options']['cxxflags'] = a_data['build-options']['cxxflags'].replace('-g0', '')
         if a_data['build-options']['cflags'].strip() == "":
             del (a_data['build-options']['cflags'])
         if a_data['build-options']['cxxflags'].strip() == "":
             del (a_data['build-options']['cxxflags'])
+
+    if 'no-debuginfo' in a_data['build-options']:
+        del (a_data['build-options']['no-debuginfo'])
 
     return a_data
 


### PR DESCRIPTION
The new linter reports this as a warning and it's hopefully not broken anymore?