### PR TITLE
Use openjdk 17 explicitly

### DIFF
--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -3,7 +3,7 @@ runtime: org.freedesktop.Platform
 runtime-version: "21.08"
 sdk: org.freedesktop.Sdk
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.openjdk
+  - org.freedesktop.Sdk.Extension.openjdk17
 command: kodi
 rename-icon: kodi
 rename-desktop-file: kodi.desktop


### PR DESCRIPTION
The org.freedesktop.Sdk.Extension.openjdk was supposed to contain a rolling openjdk version but it's currently stuck at v17 (latest is v19). Kodi flatpak uses it since https://github.com/flathub/tv.kodi.Kodi/commit/6ae4295fe3eb40d7966658d2e468f7333a31ba0d but I don't see any particular reason to always use latest openjdk (does kodi guarantee compatibility with each new release?

Using org.freedesktop.Sdk.Extension.openjdk17 (latest LTS version) explicitly may be better choice. Kodi could move to another version when it wants to and this also unblocks moving to 22.08 runtime.

Cherry-pick of @Erick555 work in https://github.com/flathub/tv.kodi.Kodi/pull/178 targeting beta now