### PR TITLE
libdav1d: stop removing libraries

### DIFF
--- a/modules/dav1d/dav1d.json
+++ b/modules/dav1d/dav1d.json
@@ -8,7 +8,6 @@
     ],
     "cleanup": [
         "/include",
-        "/lib",
         "/bin",
         "/share/doc"
     ],


### PR DESCRIPTION
Removing libraries after build makes this unusable