### PR TITLE
Makefile: Handle error in build properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ update-addons:
 	cd tools && python3 addon_updater.py -r
 	find addons -type d -not -path "addons/pvr.*" | sort | sed -r -e 's|^addons/?||' -e '/^$$/d' > addon-list.txt
 build:
-	flatpak-builder build-dir $(PROJECT).yml --repo=repo --force-clean --ccache 2>&1 | tee -a build.log
+	flatpak-builder build-dir $(PROJECT).yml --repo=repo --force-clean --ccache 2>&1 | tee -a build.log; test ${PIPESTATUS[0]} = 0
 flatpak:
 	flatpak build-bundle repo $(PROJECT).flatpak $(PROJECT)
 install:


### PR DESCRIPTION
This makes sure the return code when the build-step fails is non-zero