### PR TITLE
Add PipeWire support

### DIFF
--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -14,6 +14,7 @@ finish-args:
   - --filesystem=xdg-music
   - --filesystem=xdg-pictures
   - --filesystem=xdg-videos
+  - --filesystem=xdg-run/pipewire-0:ro
   - --filesystem=/mnt
   - --filesystem=/media
   - --filesystem=/run/media
@@ -886,6 +887,7 @@ modules:
       - -DENABLE_NFS=ON
       - -DENABLE_OPTICAL=ON
       - -DENABLE_PULSEAUDIO=ON
+      - -DENABLE_PIPEWIRE=ON
       - -DENABLE_SMBCLIENT=ON
       - -DENABLE_UDEV=ON
       - -DENABLE_UPNP=ON


### PR DESCRIPTION
The `-DENABLE_PIPEWIRE=ON` is optional as PipeWire is already build but I guess it doesn't hurt.

Fixes #240.