### PR TITLE
Allow read-only access to /run/udev to make input with GBM work

### DIFF
--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -19,6 +19,7 @@ finish-args:
   - --filesystem=/media
   - --filesystem=/run/media
   - --filesystem=/run/lirc
+  - --filesystem=/run/udev:ro
   - --share=ipc
   - --share=network
   - --socket=pulseaudio


### PR DESCRIPTION
Fixes #228, although not perfect as hot plugging doesn't work.