### PR TITLE
Bump FFmpeg to version 6.0.1

### DIFF
--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -77,8 +77,8 @@ modules:
       - /share/doc
     sources:
       - type: archive
-        url: "https://ffmpeg.org/releases/ffmpeg-6.0.tar.xz"
-        sha256: 57be87c22d9b49c112b6d24bc67d42508660e6b718b3db89c44e47e289137082
+        url: "https://ffmpeg.org/releases/ffmpeg-6.0.1.tar.xz"
+        sha256: 9b16b8731d78e596b4be0d720428ca42df642bb2d78342881ff7f5bc29fc9623
         x-checker-data:
           type: html
           url: "https://ffmpeg.org/releases/"


### PR DESCRIPTION
That's the same version the internal Kodi FFmpeg build uses.

Fixes https://github.com/xbmc/xbmc/issues/25143.