### PR TITLE
Update inputstream.adaptive to 21.4.9-Omega

### DIFF
--- a/addons/inputstream.adaptive/inputstream.adaptive.json
+++ b/addons/inputstream.adaptive/inputstream.adaptive.json
@@ -11,7 +11,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/inputstream.adaptive",
-            "commit": "a82e3eb8333187d8bb346bf5eca384524a553e57"
+            "commit": "dde35aa59187aaf255797611547add5c90c66dd2"
         },
         {
             "type": "file",


### PR DESCRIPTION
The currently used inputstream.adaptive 21.4.4-Omega has a lot of MPEG Dash bugs e.g. broken live streaming support. https://github.com/xbmc/inputstream.adaptive/issues/1517

So it would be nice to update it to latest inputstream.adaptive 21.4.9-Omega.