### PR TITLE
Beta piers updates - shared-modules, samba/smbclient, addons

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ or just search for the installed app on your system
 The following binary addons do not compile, and are excluded:
 
 - `audiodecoder.dumb`
-- `game.libretro.2048`
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,6 @@ flatpak run tv.kodi.Kodi
 
 or just search for the installed app on your system
 
-The following binary addons do not compile, and are excluded:
-
-- `audiodecoder.dumb`
-
 ## Contributing
 
 The list of binary addons in each branch of Kodi may be found

--- a/addon-list.txt
+++ b/addon-list.txt
@@ -28,6 +28,7 @@ audioencoder.wav
 game.libretro
 game.libretro.2048
 game.libretro.mrboom
+game.shader.presets
 imagedecoder.heif
 imagedecoder.mpo
 imagedecoder.raw

--- a/addons/audiodecoder.dumb/audiodecoder.dumb.json
+++ b/addons/audiodecoder.dumb/audiodecoder.dumb.json
@@ -10,8 +10,8 @@
     ],
     "build-options": {
         "no-debuginfo": true,
-        "cflags": "-g0",
-        "cxxflags": "-g0"
+        "cflags": "-g0 -fPIC",
+        "cxxflags": "-g0 -fPIC"
     },
     "config-opts": [
         "-DCMAKE_BUILD_TYPE=Release"

--- a/addons/audiodecoder.dumb/audiodecoder.dumb.json
+++ b/addons/audiodecoder.dumb/audiodecoder.dumb.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/audiodecoder.dumb",
-            "commit": "b2efbd48498b16c11ecbdfb3ef84fa6c45162837"
+            "commit": "ce13883523a93b3def9c83a15fd9b60fc170c86f"
         }
     ],
     "build-options": {

--- a/addons/audiodecoder.fluidsynth/audiodecoder.fluidsynth.json
+++ b/addons/audiodecoder.fluidsynth/audiodecoder.fluidsynth.json
@@ -17,33 +17,6 @@
         }
     ],
     "modules": [
-        {
-            "name": "fluidsynth",
-            "buildsystem": "cmake-ninja",
-            "config-opts": [
-                "-DCMAKE_BUILD_TYPE=Release",
-                "-DLIB_SUFFIX="
-            ],
-            "build-options": {
-                "no-debuginfo": true,
-                "cflags": "-g0",
-                "cxxflags": "-g0"
-            },
-            "cleanup": [
-                "/bin",
-                "/include",
-                "/lib/pkgconfig",
-                "/share/man",
-                "*.so"
-            ],
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://github.com/FluidSynth/fluidsynth.git",
-                    "tag": "v2.5.2",
-                    "commit": "2d07b6ba240d5c40c51d42b8a9ccb0373ca9e1e9"
-                }
-            ]
-        }
+        "../../shared-modules/linux-audio/fluidsynth2.json"
     ]
 }

--- a/addons/audiodecoder.ncsf/audiodecoder.ncsf.json
+++ b/addons/audiodecoder.ncsf/audiodecoder.ncsf.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/audiodecoder.ncsf",
-            "commit": "aed5eb974281414c12ec8a93827022fb199e9c0f"
+            "commit": "47fb6497202511e2b40fd7e36e10a2142513f5dc"
         }
     ],
     "build-options": {

--- a/addons/audiodecoder.sacd/audiodecoder.sacd.json
+++ b/addons/audiodecoder.sacd/audiodecoder.sacd.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/audiodecoder.sacd",
-            "commit": "3a3003e3d13406e0c19eaf14c8a8df797ccd3c9f"
+            "commit": "c630595d7122219c066136e61a35937ecd6b9abf"
         }
     ],
     "build-options": {

--- a/addons/audiodecoder.usf/audiodecoder.usf.json
+++ b/addons/audiodecoder.usf/audiodecoder.usf.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/audiodecoder.usf",
-            "commit": "1c2f1d0fec6371f1f726adcadccbf07364f47206"
+            "commit": "703a47da592f3475094d97e2d54f583870b504e6"
         }
     ],
     "build-options": {

--- a/addons/game.libretro.2048/game.libretro.2048.json
+++ b/addons/game.libretro.2048/game.libretro.2048.json
@@ -5,17 +5,30 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.2048",
-            "commit": "3d9437407828ce17e78d4cea377ede060acc758d"
+            "commit": "8ce00ed0365b9c948fe457687e8700ae8ad868df"
         }
     ],
     "modules": [
         {
             "name": "2048",
+            "buildsystem": "simple",
+            "build-options": {
+                "no-debuginfo": true,
+                "cflags": "-g0",
+                "cxxflags": "-g0"
+            },
+            "build-commands": [
+                "make -f Makefile.libretro PREFIX=/app platform=unix",
+                "install -D -m 755 2048_libretro.so /app/lib/libretro/2048_libretro.so"
+            ],
+            "cleanup": [
+                "/lib/libretro"
+            ],
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/libretro/libretro-2048/archive/20051e140346fb56376b59f41f28ef40f8ad7fb8.tar.gz",
-                    "sha256": "6cccc6ddefcd065b13aa01881ad82966eb5377657a97757c172c4e82f955780f"
+                    "url": "https://github.com/libretro/libretro-2048/archive/e70c3f82d2b861c64943aaff7fcc29a63013997d.tar.gz",
+                    "sha256": "07d51892d173d85715d0cddd5963c50c2308e2d92401c4e79208544bc95f6f19"
                 }
             ]
         }

--- a/addons/game.libretro.mrboom/game.libretro.mrboom.json
+++ b/addons/game.libretro.mrboom/game.libretro.mrboom.json
@@ -35,8 +35,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/Javanaise/mrboom-libretro/releases/download/5.2/MrBoom-src-5.2.454d614.tar.gz",
-                    "sha256": "50e4fe4bc74b23ac441499c756c4575dfe9faab9e787a3ab942a856ac63cf10d"
+                    "url": "https://github.com/kodi-game/mrboom-libretro/archive/0e52349c674860190397075ba3993efe5b65b887.tar.gz",
+                    "sha256": "89cd6c6d0f94b9e59ccc57547e401e41223f2413c88bcf1c65e791866e567dc9"
                 }
             ]
         }

--- a/addons/game.shader.presets/game.shader.presets.json
+++ b/addons/game.shader.presets/game.shader.presets.json
@@ -1,0 +1,19 @@
+{
+    "name": "game.shader.presets",
+    "buildsystem": "cmake-ninja",
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
+    ],
+    "sources": [
+        {
+            "type": "git",
+            "url": "https://github.com/kodi-game/game.shader.presets",
+            "commit": "2b5a04dccb4897d2c78093c5dc28a2852b52db6d"
+        }
+    ]
+}

--- a/addons/imagedecoder.heif/imagedecoder.heif.json
+++ b/addons/imagedecoder.heif/imagedecoder.heif.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/imagedecoder.heif",
-            "commit": "ad9a43c3ef886bee88b745b17511ea1c7f99ab5b"
+            "commit": "2576fd07c2782f1ce4ad4d6a1d79e9c3b78961bd"
         }
     ],
     "modules": [

--- a/addons/imagedecoder.raw/imagedecoder.raw.json
+++ b/addons/imagedecoder.raw/imagedecoder.raw.json
@@ -5,7 +5,6 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/imagedecoder.raw",
-            "tag": "22.0.3-Piers",
             "commit": "7349812be6a0a7c817339d2c5c0f27562f039e73"
         }
     ],

--- a/addons/inputstream.adaptive/inputstream.adaptive.json
+++ b/addons/inputstream.adaptive/inputstream.adaptive.json
@@ -11,7 +11,6 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/inputstream.adaptive",
-            "tag": "22.3.7-Piers",
             "commit": "195161ad8159905842d9f3c87317917184926cdd"
         },
         {

--- a/addons/inputstream.ffmpegdirect/inputstream.ffmpegdirect.json
+++ b/addons/inputstream.ffmpegdirect/inputstream.ffmpegdirect.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/inputstream.ffmpegdirect",
-            "commit": "413b8548899c790cc6e33c9303de8d8b47d111bf"
+            "commit": "4dfe657e9a2ce164e92a0f8abbf81c5e0f44fb67"
         }
     ],
     "build-options": {

--- a/addons/inputstream.rtmp/inputstream.rtmp.json
+++ b/addons/inputstream.rtmp/inputstream.rtmp.json
@@ -5,7 +5,6 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/inputstream.rtmp",
-            "tag": "22.1.1-Piers",
             "commit": "df26961e0f4ad466f7d3e63b93f3a0cc7b04092a"
         }
     ],

--- a/addons/pvr.argustv/pvr.argustv.json
+++ b/addons/pvr.argustv/pvr.argustv.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.argustv",
-            "commit": "da7c4a1d89ad8108757e06f3d3330f038767bb10"
+            "commit": "6a60a1782aeb746f2e30a510d1ffafcb44d955ed"
         }
     ],
     "build-options": {

--- a/addons/pvr.demo/pvr.demo.json
+++ b/addons/pvr.demo/pvr.demo.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.demo",
-            "commit": "ac17a1f683be30157d8057cee2e3fde3bfe610ba"
+            "commit": "c63e88f6e34573d0aab656f190fc6ca77e9ad476"
         }
     ],
     "build-options": {

--- a/addons/pvr.dvblink/pvr.dvblink.json
+++ b/addons/pvr.dvblink/pvr.dvblink.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.dvblink",
-            "commit": "9e58464ee5ead74dc1c2568e3386e88af58f6250"
+            "commit": "45abea0973142756bb2c2e93fc6fd4388779dfe0"
         }
     ],
     "build-options": {

--- a/addons/pvr.dvbviewer/pvr.dvbviewer.json
+++ b/addons/pvr.dvbviewer/pvr.dvbviewer.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.dvbviewer",
-            "commit": "bd50490e1fd763954bacd6b3cce1cbfbe17aae38"
+            "commit": "fd18b05576e45bc6c2aec8c79947047bf374dfa5"
         }
     ],
     "build-options": {

--- a/addons/pvr.filmon/pvr.filmon.json
+++ b/addons/pvr.filmon/pvr.filmon.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.filmon",
-            "commit": "752899eb7d36081f178c574dc07c97770bd240f4"
+            "commit": "39827c842b84265c7bfa5c8600b2604e5824e7b5"
         }
     ],
     "build-options": {

--- a/addons/pvr.hdhomerun/pvr.hdhomerun.json
+++ b/addons/pvr.hdhomerun/pvr.hdhomerun.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.hdhomerun",
-            "commit": "1706fe9b955d77d4246d451e49f509c31085477b"
+            "commit": "276700b67f4f29b2507068aa5ed37668f4555137"
         }
     ],
     "modules": [

--- a/addons/pvr.hts/pvr.hts.json
+++ b/addons/pvr.hts/pvr.hts.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.hts",
-            "commit": "0942d66991f096c5251f5556a2ad8d7cf339062b"
+            "commit": "0c6b4c9c1584d51c39ad3d1f75f2c25552220be1"
         }
     ],
     "build-options": {

--- a/addons/pvr.iptvsimple/pvr.iptvsimple.json
+++ b/addons/pvr.iptvsimple/pvr.iptvsimple.json
@@ -5,13 +5,13 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.iptvsimple",
-            "commit": "084876e470fed21400642aa7b34bf65982286e0f"
+            "commit": "047fcee070816b8f8ebaf9644c5f73c04bbdf3e1"
         }
     ],
     "build-options": {
         "no-debuginfo": true,
-        "cflags": "-g0",
-        "cxxflags": "-g0 -Wp,-U_GLIBCXX_ASSERTIONS"
+        "cxxflags": "-g0 -Wp,-U_GLIBCXX_ASSERTIONS",
+        "cflags": "-g0"
     },
     "config-opts": [
         "-DCMAKE_BUILD_TYPE=Release"

--- a/addons/pvr.mediaportal.tvserver/pvr.mediaportal.tvserver.json
+++ b/addons/pvr.mediaportal.tvserver/pvr.mediaportal.tvserver.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.mediaportal.tvserver",
-            "commit": "32b63a0414dfe4ad29b47bb126ebe4c8354c8f6e"
+            "commit": "17aeea8f9966d8ff72f659dfbd1b22108d261494"
         }
     ],
     "build-options": {

--- a/addons/pvr.mythtv/pvr.mythtv.json
+++ b/addons/pvr.mythtv/pvr.mythtv.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/janbar/pvr.mythtv",
-            "commit": "b113c2b930a709d92cbce13cd1f34819aa3af5b4"
+            "commit": "b94390d48c00da9c3ffd09a08f18a091669c6fcd"
         }
     ],
     "build-options": {

--- a/addons/pvr.nextpvr/pvr.nextpvr.json
+++ b/addons/pvr.nextpvr/pvr.nextpvr.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.nextpvr",
-            "commit": "558cbcc304f5824e536fd013b1528b3a51763df4"
+            "commit": "f0446669f4188efda4487d12e71ecc27ec6b66dd"
         }
     ],
     "build-options": {

--- a/addons/pvr.njoy/pvr.njoy.json
+++ b/addons/pvr.njoy/pvr.njoy.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.njoy",
-            "commit": "bdc306faa775e3f986eab818922f1908f141ba45"
+            "commit": "e53ee6f45e4080b78a811b2d344661e96d19f0fd"
         }
     ],
     "build-options": {

--- a/addons/pvr.pctv/pvr.pctv.json
+++ b/addons/pvr.pctv/pvr.pctv.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.pctv",
-            "commit": "53364a0d281c77c6f47b6a69d74a77056673f09a"
+            "commit": "ef0717148c5d90396447a535e749ccce0c00cefc"
         }
     ],
     "build-options": {

--- a/addons/pvr.plutotv/pvr.plutotv.json
+++ b/addons/pvr.plutotv/pvr.plutotv.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.plutotv",
-            "commit": "a31a347de5846768ec3baaea7081e70a2ed9b0e5"
+            "commit": "e365c4140dfde360ad3156faafa6cd3ad8f93c24"
         }
     ],
     "build-options": {

--- a/addons/pvr.sledovanitv.cz/pvr.sledovanitv.cz.json
+++ b/addons/pvr.sledovanitv.cz/pvr.sledovanitv.cz.json
@@ -5,8 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/palinek/pvr.sledovanitv.cz",
-            "tag": "22.6.1-Piers",
-            "commit": "ee8f7482e5cfdd66f00c9cfafaddad172f324457"
+            "commit": "9ded28759c46478087c45f7500237139c1ab8c47"
         }
     ],
     "build-options": {

--- a/addons/pvr.stalker/pvr.stalker.json
+++ b/addons/pvr.stalker/pvr.stalker.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.stalker",
-            "commit": "16a2c80451dc084a9e937ad854cfbb3455d0bc75"
+            "commit": "ec2df60a0bc19c6a3b0680a4b58b3e98619554c2"
         }
     ],
     "build-options": {

--- a/addons/pvr.vbox/pvr.vbox.json
+++ b/addons/pvr.vbox/pvr.vbox.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.vbox",
-            "commit": "ebd71371a7dd7e8574fe7ebea87b0e21289af287"
+            "commit": "c331c13d00ac82440e30b0ff32a16197b5dac22d"
         }
     ],
     "build-options": {

--- a/addons/pvr.vdr.vnsi/pvr.vdr.vnsi.json
+++ b/addons/pvr.vdr.vnsi/pvr.vdr.vnsi.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.vdr.vnsi",
-            "commit": "a576ed7e0c224ba81c806418f3aec7d87577dda3"
+            "commit": "a4b4cfd8b543b68634ff76f281d26716a4cde257"
         }
     ],
     "build-options": {

--- a/addons/pvr.vuplus/pvr.vuplus.json
+++ b/addons/pvr.vuplus/pvr.vuplus.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.vuplus",
-            "commit": "de97600867d6a545e285db3282955ba05a4c9d98"
+            "commit": "e5c49dae795e12471ab9e577457ac6f6571a74c9"
         }
     ],
     "build-options": {

--- a/addons/pvr.waipu/pvr.waipu.json
+++ b/addons/pvr.waipu/pvr.waipu.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/flubshi/pvr.waipu",
-            "commit": "a59797eae0e215460593d4d69fa4115e81715287"
+            "commit": "ef6f565cba696f1f41c5ff8839bc86b8f627f645"
         }
     ],
     "build-options": {

--- a/addons/pvr.wmc/pvr.wmc.json
+++ b/addons/pvr.wmc/pvr.wmc.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.wmc",
-            "commit": "bfbcab661917944a1dc1aa800f168ae0d58ed1e6"
+            "commit": "885514cccc6f99b65121861259b5d84dd2905e1f"
         }
     ],
     "build-options": {

--- a/addons/screensaver.asterwave/screensaver.asterwave.json
+++ b/addons/screensaver.asterwave/screensaver.asterwave.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/screensaver.asterwave",
-            "commit": "a4fae4881ded790b73d3d3d1a29fa3204f233bea"
+            "commit": "24aa76188fa661ba49ae859a5df47fd06cd8303c"
         }
     ],
     "build-options": {

--- a/addons/screensaver.greynetic/screensaver.greynetic.json
+++ b/addons/screensaver.greynetic/screensaver.greynetic.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/screensaver.greynetic",
-            "commit": "956485bf7268be35e8643c7f90b6b6823cc6779a"
+            "commit": "c9b7b78e28e7239802b8d9dfa521719c26d064f1"
         }
     ],
     "build-options": {

--- a/addons/screensaver.stars/screensaver.stars.json
+++ b/addons/screensaver.stars/screensaver.stars.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/screensaver.stars",
-            "commit": "8ceccc190ef41df3a1ffad9e43e498d4d1814828"
+            "commit": "286e542a3b2cef5ae45d7593db04787a7b2934e7"
         }
     ],
     "build-options": {

--- a/addons/screensavers.rsxs/screensavers.rsxs.json
+++ b/addons/screensavers.rsxs/screensavers.rsxs.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/screensavers.rsxs",
-            "commit": "c30312e1fb22ba426dc6680134a4c0c0136f5d45"
+            "commit": "1e9571d30c3d96244a08705cde3f311a61a558a7"
         }
     ],
     "build-options": {

--- a/addons/vfs.rar/vfs.rar.json
+++ b/addons/vfs.rar/vfs.rar.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/vfs.rar",
-            "commit": "8141976a79016cc6b87b65b4c1bfea24498e90d4"
+            "commit": "2b14ddf152e9da16496cdc219e7c1e587896c721"
         }
     ],
     "build-options": {

--- a/addons/visualization.fishbmc/visualization.fishbmc.json
+++ b/addons/visualization.fishbmc/visualization.fishbmc.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/visualization.fishbmc",
-            "commit": "57ddb7874ac83b4f7c2fbbd5442a7c81a1002618"
+            "commit": "af494d0f0096f3baa3866ff31c1bd1ce7ce0c00c"
         }
     ],
     "build-options": {

--- a/addons/visualization.matrix/visualization.matrix.json
+++ b/addons/visualization.matrix/visualization.matrix.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/visualization.matrix",
-            "commit": "740ffddc08af007c6e29b14daa410377f4d2a1bb"
+            "commit": "4b82fdaa9f5e86d2daa685021c57fa2d395494fd"
         }
     ],
     "build-options": {

--- a/addons/visualization.pictureit/visualization.pictureit.json
+++ b/addons/visualization.pictureit/visualization.pictureit.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/visualization.pictureit",
-            "commit": "8fce17e11adeae6376cfb540b4593c6dfaad6ad3"
+            "commit": "e1c03dd753a0a8bb6c7b4f637d90ebf2b8e3bf2f"
         }
     ],
     "build-options": {

--- a/addons/visualization.projectm/visualization.projectm.json
+++ b/addons/visualization.projectm/visualization.projectm.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/visualization.projectm",
-            "commit": "e0ceab8759ecfc3d5b318709b027484c0bcc88fd"
+            "commit": "0cc3bacfdb620db550e35cd628a68b33534db8ba"
         }
     ],
     "modules": [

--- a/addons/visualization.spectrum/visualization.spectrum.json
+++ b/addons/visualization.spectrum/visualization.spectrum.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/visualization.spectrum",
-            "commit": "227a7c07a5f4c5fa257cf4567f2531f984c8572d"
+            "commit": "2431c50bf1086751ca7e98f4fe0b94c02455fc77"
         }
     ],
     "build-options": {

--- a/tools/addon_updater.py
+++ b/tools/addon_updater.py
@@ -100,11 +100,12 @@ def set_build_type(a_data):
             a_data["config-opts"].append("-DCMAKE_BUILD_TYPE=Release")
         a_data["build-options"]["no-debuginfo"] = True
         a_data["build-options"]["cflags"] = "-g0"
-        a_data["build-options"]["cxxflags"] = (
-            "-g0"
-            if a_data["name"] != "pvr.iptvsimple"
-            else "-g0 -Wp,-U_GLIBCXX_ASSERTIONS"
-        )
+        a_data["build-options"]["cxxflags"] = "-g0"
+        if a_data["name"] == "pvr.iptvsimple":
+            a_data["build-options"]["cxxflags"] += " -Wp,-U_GLIBCXX_ASSERTIONS"
+        elif a_data["name"] == "audiodecoder.dumb":
+            a_data["build-options"]["cflags"] += " -fPIC"
+            a_data["build-options"]["cxxflags"] += " -fPIC"
     else:
         if "-DCMAKE_BUILD_TYPE=Release" in a_data["config-opts"]:
             a_data["config-opts"].remove("-DCMAKE_BUILD_TYPE=Release")

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -976,7 +976,7 @@ modules:
   - addons/audioencoder.vorbis/audioencoder.vorbis.json
   - addons/audioencoder.wav/audioencoder.wav.json
   - addons/game.libretro/game.libretro.json
-  # - addons/game.libretro.2048/game.libretro.2048.json
+  - addons/game.libretro.2048/game.libretro.2048.json
   - addons/game.libretro.mrboom/game.libretro.mrboom.json
   - addons/imagedecoder.heif/imagedecoder.heif.json
   - addons/imagedecoder.mpo/imagedecoder.mpo.json

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -668,38 +668,6 @@ modules:
             url: https://archive.apache.org/dist/commons/text/binaries/commons-text-1.15.0-bin.tar.gz
             sha512: 6d1fcbd85a85f38e95ea33c9ab7f58798723b0e6357077246a135c417e75c7b39e278ebdb77fcc8f9b56b52b1eeff113eea9463eaaaee8d38df9afdc149b6421
             dest: commons-text
-  - name: taglib2
-    buildsystem: cmake-ninja
-    config-opts:
-      - -DBUILD_SHARED_LIBS=ON
-      - -DBUILD_EXAMPLES=OFF
-      - -DBUILD_TESTING=OFF
-      - -DBUILD_BINDINGS=OFF
-      - -DCMAKE_INSTALL_LIBDIR=lib
-    cleanup:
-      - /include
-      - /lib/*.so
-    modules:
-      - name: utf8cpp
-        buildsystem: cmake-ninja
-        config-opts:
-          - -DCMAKE_INSTALL_LIBDIR=lib
-        sources:
-          - type: archive
-            url: https://github.com/nemtrif/utfcpp/archive/refs/tags/v4.0.9.tar.gz
-            sha512: 02e2b84b5ea827dfbc7fc1fef52e30d72fb2aca3e81ea7780d0286fe67c49500b3acf8f877af2b5feac81af2244341b9052ffbceed774e5442a8184785207478
-            x-checker-data:
-              type: anitya
-              project-id: 20545
-              url-template: https://github.com/nemtrif/utfcpp/archive/refs/tags/v$version.tar.gz
-    sources:
-      - type: archive
-        url: https://taglib.org/releases/taglib-2.1.1.tar.gz
-        sha512: 00ff982cd8e08307b453221e0c7fa471006640e906ac98df5f26abe5e302ffa09e17fd32e583508bda5ea060d6d6c7eae811efe00e5faa2f2570931243433c0b
-        x-checker-data:
-          type: anitya
-          project-id: 1982
-          url-template: https://taglib.org/releases/taglib-$version.tar.gz
   - name: tinyxml
     cleanup:
       - /include

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -174,6 +174,8 @@ modules:
       - /lib/pkgconfig
   - name: json
     buildsystem: cmake-ninja
+    config-opts:
+      - -DJSON_BuildTests=OFF
     sources:
       - type: archive
         url: https://github.com/nlohmann/json/archive/refs/tags/v3.12.0.tar.gz
@@ -516,18 +518,6 @@ modules:
         dest-filename: autogen.sh
         commands:
           - autoreconf -vfi
-  - name: nlohmannjson
-    buildsystem: cmake-ninja
-    config-opts:
-      - -DJSON_BuildTests=OFF
-    sources:
-      - type: git
-        url: https://github.com/nlohmann/json.git
-        tag: v3.12.0
-        commit: 55f93686c01528224f448c19128836e7df245f72
-        x-checker-data:
-          type: git
-          tag-pattern: ^v([\d.]+)$
   - name: samba
     buildsystem: autotools
     config-opts:

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -481,16 +481,6 @@ modules:
         x-checker-data:
           type: git
           tag-pattern: ^([\d.]+)$
-  - name: python3-yaml
-    buildsystem: simple
-    build-commands:
-      - >-
-        pip3 install --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "pyyaml" --no-build-isolation
-    sources:
-      - type: file
-        url: https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz
-        sha256: d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f
   - name: lirc
     rm-configure: true
     config-opts:

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -330,7 +330,8 @@ modules:
         sources:
           - type: git
             url: https://github.com/xbmc/platform.git
-            commit: 87e2b4ec3af12e8ff07ee1bb437cd17c02101567
+            tag: p8-platform-20260129
+            commit: c51ddf4787d083b6cf039761a48fb90d0c4f00ff
   - name: libdisplay-info
     buildsystem: meson
     sources:

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -547,8 +547,8 @@ modules:
         PERL5LIB: /app/lib/perl5
     sources:
       - type: archive
-        url: https://download.samba.org/pub/samba/stable/samba-4.23.4.tar.gz
-        sha256: af429d078a86f1ce16d0d1ecee35c42a3610790b47b84468f31284a8c4060140
+        url: https://download.samba.org/pub/samba/stable/samba-4.23.5.tar.gz
+        sha256: 593a43ddd0d57902237dfa76888f7b02cb7fc7747111369cb31e126db4836b9f
         x-checker-data:
           type: anitya
           project-id: 4758

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -443,7 +443,6 @@ modules:
           type: anitya
           project-id: 89591
           url-template: http://mirrors.kodi.tv/build-deps/sources/libudfread-$version.tar.gz
-  - shared-modules/lzo/lzo.json
   - name: mariadb-connector
     buildsystem: cmake-ninja
     config-opts:

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -561,6 +561,10 @@ modules:
       - /share
       - /include
       - /lib/*.so
+      - /lib/perl5
+    build-options:
+      env:
+        PERL5LIB: /app/lib/perl5
     sources:
       - type: archive
         url: https://download.samba.org/pub/samba/stable/samba-4.23.4.tar.gz
@@ -570,25 +574,10 @@ modules:
           project-id: 4758
           url-template: https://download.samba.org/pub/samba/stable/samba-$version.tar.gz
     modules:
-      - name: perl
-        no-autogen: true
-        config-opts:
-          - -des
-        post-install:
-          - find ${FLATPAK_DEST}/lib/perl5/5.42.0/${FLATPAK_ARCH}-linux/auto/ -name
-            \*.so -exec chmod u+w {} +
-        sources:
-          - type: archive
-            url: https://www.cpan.org/src/5.0/perl-5.42.0.tar.gz
-            sha256: e093ef184d7f9a1b9797e2465296f55510adb6dab8842b0c3ed53329663096dc
-          - type: script
-            dest-filename: configure
-            commands:
-              - exec ./configure.gnu $@
       - name: parse-yapp
         buildsystem: simple
         build-commands:
-          - perl Makefile.PL
+          - perl Makefile.PL PREFIX=/app LIB=/app/lib/perl5
           - make
           - make install
         sources:

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -950,7 +950,7 @@ modules:
 
   - addons/audiodecoder.2sf/audiodecoder.2sf.json
   - addons/audiodecoder.asap/audiodecoder.asap.json
-  # - addons/audiodecoder.dumb/audiodecoder.dumb.json
+  - addons/audiodecoder.dumb/audiodecoder.dumb.json
   - addons/audiodecoder.fluidsynth/audiodecoder.fluidsynth.json
   - addons/audiodecoder.gme/audiodecoder.gme.json
   - addons/audiodecoder.gsf/audiodecoder.gsf.json

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -172,6 +172,16 @@ modules:
           url-template: https://github.com/vcrhonek/hwdata/archive/refs/tags/v$version.tar.gz
     cleanup:
       - /lib/pkgconfig
+  - name: json
+    buildsystem: cmake-ninja
+    sources:
+      - type: archive
+        url: https://github.com/nlohmann/json/archive/refs/tags/v3.12.0.tar.gz
+        sha256: 4b92eb0c06d10683f7447ce9406cb97cd4b453be18d7279320f7b2f025c10187
+        x-checker-data:
+          type: anitya
+          project-id: 11152
+          url-template: https://github.com/nlohmann/json/archive/refs/tags/v$version.tar.gz
   - name: jsoncpp
     buildsystem: meson
     config-opts:
@@ -506,6 +516,18 @@ modules:
         dest-filename: autogen.sh
         commands:
           - autoreconf -vfi
+  - name: nlohmannjson
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DJSON_BuildTests=OFF
+    sources:
+      - type: git
+        url: https://github.com/nlohmann/json.git
+        tag: v3.12.0
+        commit: 55f93686c01528224f448c19128836e7df245f72
+        x-checker-data:
+          type: git
+          tag-pattern: ^v([\d.]+)$
   - name: samba
     buildsystem: autotools
     config-opts:

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -915,6 +915,7 @@ modules:
   - addons/game.libretro/game.libretro.json
   - addons/game.libretro.2048/game.libretro.2048.json
   - addons/game.libretro.mrboom/game.libretro.mrboom.json
+  - addons/game.shader.presets/game.shader.presets.json
   - addons/imagedecoder.heif/imagedecoder.heif.json
   - addons/imagedecoder.mpo/imagedecoder.mpo.json
   - addons/imagedecoder.raw/imagedecoder.raw.json

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -172,16 +172,6 @@ modules:
           url-template: https://github.com/vcrhonek/hwdata/archive/refs/tags/v$version.tar.gz
     cleanup:
       - /lib/pkgconfig
-  - name: json
-    buildsystem: cmake-ninja
-    sources:
-      - type: archive
-        url: https://github.com/nlohmann/json/archive/refs/tags/v3.12.0.tar.gz
-        sha256: 4b92eb0c06d10683f7447ce9406cb97cd4b453be18d7279320f7b2f025c10187
-        x-checker-data:
-          type: anitya
-          project-id: 11152
-          url-template: https://github.com/nlohmann/json/archive/refs/tags/v$version.tar.gz
   - name: jsoncpp
     buildsystem: meson
     config-opts:
@@ -526,18 +516,6 @@ modules:
         dest-filename: autogen.sh
         commands:
           - autoreconf -vfi
-  - name: nlohmannjson
-    buildsystem: cmake-ninja
-    config-opts:
-      - -DJSON_BuildTests=OFF
-    sources:
-      - type: git
-        url: https://github.com/nlohmann/json.git
-        tag: v3.12.0
-        commit: 55f93686c01528224f448c19128836e7df245f72
-        x-checker-data:
-          type: git
-          tag-pattern: ^v([\d.]+)$
   - name: samba
     buildsystem: autotools
     config-opts:


### PR DESCRIPTION
This pull request:
- updates shared-modules to latest githash (there were no changes to the modules kodi currently imports)
- uses fluidsynth from shared-modules instead of git snapshot
- updates game.libretro.mrboom to latest
- updates game.libretro.2048 to latest and adapts build system
- fixes build of audiodecoder.dumb
- drops several modules included in runtime 25.08
  - lzo
  - perl
  - pyaml
  - taglib
  - utf8cpp
- updates samba to latest release
- updates p8 platform to p8-platform-20260129
- updates all addons to latest Piers/master banch githashes