### PR TITLE
game.libretro: drop dup tinyxml, it is already provided by manifest

### DIFF
--- a/addons/game.libretro/game.libretro.json
+++ b/addons/game.libretro/game.libretro.json
@@ -23,30 +23,6 @@
     ],
     "modules": [
         {
-            "name": "tinyxml",
-            "cleanup": [
-                "/include",
-                "/share/doc",
-                "*.a",
-                "*.la",
-                "/lib/*.so"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "http://mirrors.kodi.tv/build-deps/sources/tinyxml-2.6.2_2.tar.gz",
-                    "sha256": "8164c9ad48b9028667768a584d62f7760cfbfb90d0dd6214ad174403058da10c"
-                },
-                {
-                    "type": "script",
-                    "dest-filename": "autogen.sh",
-                    "commands": [
-                        "autoreconf -vfi"
-                    ]
-                }
-            ]
-        },
-        {
             "name": "libretro-common",
             "buildsystem": "cmake-ninja",
             "build-options": {


### PR DESCRIPTION
Please consider merging https://github.com/flathub/tv.kodi.Kodi/pull/666 before this to avoid future rebasing with conflict resolution.