### PR TITLE
Disable airtunes support (broken beyond repair)

### DIFF
--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -549,7 +549,7 @@ modules:
           - type: archive
             url: https://cpan.metacpan.org/authors/id/W/WB/WBRASWELL/Parse-Yapp-1.21.tar.gz
             sha256: 3810e998308fba2e0f4f26043035032b027ce51ce5c8a52a8b8e340ca65f13e5
-  - name: shairplay
+  - name: avahi
     cleanup:
       - /include
       - /bin
@@ -557,45 +557,28 @@ modules:
       - '*.la'
       - /lib/*.so
       - /share/runtime/locale
-    build-options:
-      env:
-        C_INCLUDE_PATH: /app/include/avahi-compat-libdns_sd:/app/include
+    config-opts:
+      - --with-distro=none
+      - --disable-libdaemon
+      - --disable-libsystemd
+      - --disable-nls
+      - --disable-core-docs
+      - --disable-manpages
+      - --disable-mono
+      - --disable-libevent
+      - --disable-qt4
+      - --disable-qt5
+      - --disable-python
+      - --disable-gtk
+      - --disable-gtk3
     sources:
-      - type: git
-        url: https://github.com/juhovh/shairplay/
-        commit: 096b61ad14c90169f438e690d096e3fcf87e504e
-    modules:
-      - name: avahi
-        cleanup:
-          - /include
-          - /bin
-          - '*.a'
-          - '*.la'
-          - /lib/*.so
-          - /share/runtime/locale
-        config-opts:
-          - --with-distro=none
-          - --disable-libdaemon
-          - --disable-libsystemd
-          - --disable-nls
-          - --disable-core-docs
-          - --disable-manpages
-          - --disable-mono
-          - --disable-libevent
-          - --disable-qt4
-          - --disable-qt5
-          - --disable-python
-          - --disable-gtk
-          - --disable-gtk3
-          - --enable-compat-libdns_sd
-        sources:
-          - type: archive
-            url: https://github.com/avahi/avahi/archive/refs/tags/v0.9-rc3.tar.gz
-            sha256: 9f2ff92864c56364d711eb2acec4c0455d1375d8c3266e420611730a2c9ccba5
-            x-checker-data:
-              type: anitya
-              project-id: 147
-              url-template: https://github.com/avahi/avahi/archive/refs/tags/v$version.tar.gz
+      - type: archive
+        url: https://github.com/avahi/avahi/archive/refs/tags/v0.9-rc3.tar.gz
+        sha256: 9f2ff92864c56364d711eb2acec4c0455d1375d8c3266e420611730a2c9ccba5
+        x-checker-data:
+            type: anitya
+            project-id: 147
+            url-template: https://github.com/avahi/avahi/archive/refs/tags/v$version.tar.gz
   - name: spdlog
     buildsystem: cmake-ninja
     config-opts:
@@ -774,7 +757,6 @@ modules:
       - -DADDONS_CONFIGURE_AT_STARTUP=OFF
       - -DVERBOSE=1
       - -DENABLE_TESTING=OFF
-      - -DENABLE_AIRTUNES=ON
       - -DENABLE_ALSA=ON
       - -DENABLE_AVAHI=ON
       - -DENABLE_BLURAY=ON


### PR DESCRIPTION
Remove shairplay avahi-compat-libdns_sd from manifest. Shairplay is incompatible with iOS versions since ~2019, and abandoned upstream. c.f. https://github.com/juhovh/shairplay/pull/80