### PR TITLE
master updates

### DIFF
--- a/addons/game.libretro/game.libretro.json
+++ b/addons/game.libretro/game.libretro.json
@@ -85,7 +85,7 @@
                     "type": "file",
                     "//": "Update this when updating from Omega",
                     "url": "https://raw.githubusercontent.com/kodi-game/game.libretro/3b3aa934198ccbf0c25138e10a579db1db8f4ffe/depends/common/rcheevos/CMakeLists.txt",
-                    "sha256": "33662a2bfff8a17d7707c5b8a0239bb00d559302975e7b9b7e0eac1f2e6c10c5"
+                    "sha256": "76896119cc13623975abbf99587221f6de8f9b2733ce0729df3c35794ec5783b"
                 }
             ]
         }

--- a/addons/game.libretro/game.libretro.json
+++ b/addons/game.libretro/game.libretro.json
@@ -63,7 +63,7 @@
                 {
                     "type": "file",
                     "url": "https://raw.githubusercontent.com/kodi-game/game.libretro/Omega/depends/common/libretro-common/CMakeLists.txt",
-                    "sha256": "fe0698a56bf869f8c6af2cbd0cc3dc9c05c370141009fa4777373538c1a41af1"
+                    "sha256": "e45d4f77e57478ba27e6bcfcab2f7b641061cea24efd836e3d082e45cd0b688f"
                 }
             ]
         },

--- a/addons/vfs.sftp/vfs.sftp.json
+++ b/addons/vfs.sftp/vfs.sftp.json
@@ -25,14 +25,10 @@
             },
             "sources": [
                 {
-                    "type": "archive",
-                    "url": "https://www.libssh.org/files/0.9/libssh-0.9.5.tar.xz",
-                    "sha256": "acffef2da98e761fc1fd9c4fddde0f3af60ab44c4f5af05cd1b2d60a3fa08718",
-                    "x-checker-data": {
-                        "type": "anitya",
-                        "project-id": 1729,
-                        "url-template": "https://www.libssh.org/files/$version0.$version1/libssh-$version.tar.xz"
-                    }
+                    "type": "git",
+                    "url": "https://git.libssh.org/projects/libssh.git/",
+                    "tag": "libssh-0.12.0",
+                    "commit": "50313883f3a077458cde4ea95bf46bfeb0771b34"
                 }
             ]
         }

--- a/patches/libbdplus-fix-libgcrypt.patch
+++ b/patches/libbdplus-fix-libgcrypt.patch
@@ -1,0 +1,25 @@
+Description: libgcrypt does not ship libgcrypt-config anymore,
+ instead use PKG_CHECK_MODULES to detect libgcrypt
+Author: Dylan Aïssi <daissi@debian.org>
+Bug-Debian: https://bugs.debian.org/1071932
+Last-Update: 2024-06-29
+--- a/configure.ac
++++ b/configure.ac
+@@ -119,16 +119,7 @@
+       LIBGCRYPT_CONFIG=$libgcrypt_config_prefix/bin/libgcrypt-config
+    fi
+ fi
+-
+-AC_PATH_PROG(LIBGCRYPT_CONFIG, libgcrypt-config, no)
+-if test x"$LIBGCRYPT_CONFIG" = xno; then
+-  AC_MSG_ERROR([libgcrypt not found on system])
+-else
+-  LIBGCRYPT_CFLAGS=`$LIBGCRYPT_CONFIG --cflags`
+-  LIBGCRYPT_LIBS=`$LIBGCRYPT_CONFIG --libs`
+-  AC_SUBST(LIBGCRYPT_CFLAGS)
+-  AC_SUBST(LIBGCRYPT_LIBS)
+-fi
++PKG_CHECK_MODULES([LIBGCRYPT],libgcrypt,AC_DEFINE(HAVE_LIBGCRYPT_ERROR, 1, [Define to 1 if you have the libgcrypt library]),AC_MSG_ERROR([libgcrypt not found on system]))
+ AC_FUNC_STRERROR_R
+ 
+ dnl use re-entrant version of gcrypt_error() from gpg-error

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -177,8 +177,8 @@ modules:
       - --datarootdir=${FLATPAK_DEST}/lib/
     sources:
       - type: archive
-        url: https://github.com/vcrhonek/hwdata/archive/refs/tags/v0.403.tar.gz
-        sha256: 77d0a69e5558d16d33bbb510a09093deaf11c882baf9ef6ec5f18a8ef96e2c13
+        url: https://github.com/vcrhonek/hwdata/archive/refs/tags/v0.406.tar.gz
+        sha256: 1ccfd1ca723595b1fe8794f4157ec5635be1ebedb5d13769b4be75d0b75bc199
         x-checker-data:
           type: anitya
           project-id: 13577

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -203,8 +203,8 @@ modules:
       - -Dtests=false
     sources:
       - type: archive
-        url: https://github.com/open-source-parsers/jsoncpp/archive/1.9.6.tar.gz
-        sha256: f93b6dd7ce796b13d02c108bc9f79812245a82e577581c4c9aabe57075c90ea2
+        url: https://github.com/open-source-parsers/jsoncpp/archive/1.9.7.tar.gz
+        sha256: 830bf352d822d8558e9d0eb19d640d2e38536b4b6699c30a4488da09d5b1df18
         x-checker-data:
           type: anitya
           project-id: 7483

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -143,7 +143,6 @@ modules:
           type: anitya
           project-id: 7320
           url-template: http://fstrcmp.sourceforge.net/fstrcmp-$version.tar.gz
-  - shared-modules/glu/glu-9.json
   - name: glm
     buildsystem: cmake-ninja
     config-opts:

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -254,6 +254,7 @@ modules:
               stable-only: true
               url-template: https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-$version.tar.bz2
   - name: libaacs
+    rm-configure: true
     config-opts:
       - --with-pic
       - --enable-shared
@@ -266,6 +267,11 @@ modules:
           type: anitya
           project-id: 5562
           url-template: https://download.videolan.org/videolan/libaacs/$version/libaacs-$version.tar.bz2
+      - type: script
+        dest-filename: autogen.sh
+        commands:
+          - rm -fv m4/libgcrypt.m4
+          - autoreconf -vfi
   - name: libbdplus
     rm-configure: true
     config-opts:

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -227,22 +227,19 @@ modules:
           type: anitya
           project-id: 1560
           url-template: https://github.com/libass/libass/archive/refs/tags/$version.tar.gz
-    # libgcrypt-1.11.0 build fails with freedeskop 24.08
   - name: libgcrypt
     config-opts:
       - --disable-static
       - --disable-doc
     sources:
-      - type: git
-        url: https://dev.gnupg.org/source/libgcrypt.git
-        tag: libgcrypt-1.10.3
-        commit: aa1610866f8e42bdc272584f0a717f32ee050a22
-        # disabled for libgcrypt-1.11 because of build fail
-        #x-checker-data:
-        #  type: anitya
-        #  project-id: 1623
-        #  stable-only: true
-        #  tag-template: libgcrypt-$version
+      - type: archive
+        url: https://www.gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.12.1.tar.bz2
+        sha512: e4be1f9d32bb672663499a1203454b9c646b7f237d9acb64303b991798fe3f4c3366793b0564b94c6687885353f6e7fef6ae6e74a57ccb5eb5606e77c81b3738
+        x-checker-data:
+         type: anitya
+         project-id: 1623
+         stable-only: true
+         tag-template: libgcrypt-$versio
   - name: libaacs
     config-opts:
       - --with-pic

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -235,10 +235,24 @@ modules:
         url: https://www.gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.12.1.tar.bz2
         sha512: e4be1f9d32bb672663499a1203454b9c646b7f237d9acb64303b991798fe3f4c3366793b0564b94c6687885353f6e7fef6ae6e74a57ccb5eb5606e77c81b3738
         x-checker-data:
-         type: anitya
-         project-id: 1623
-         stable-only: true
-         tag-template: libgcrypt-$versio
+          type: anitya
+          project-id: 1623
+          stable-only: true
+          tag-template: libgcrypt-$version
+    modules:
+      - name: libgpg-error
+        config-opts:
+          - --disable-static
+          - --disable-doc
+        sources:
+          - type: archive
+            url: https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.59.tar.bz2
+            sha256: a19bc5087fd97026d93cb4b45d51638d1a25202a5e1fbc3905799f424cfa6134
+            x-checker-data:
+              type: anitya
+              project-id: 1628
+              stable-only: true
+              url-template: https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-$version.tar.bz2
   - name: libaacs
     config-opts:
       - --with-pic

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -290,6 +290,8 @@ modules:
           url-template: https://download.videolan.org/videolan/libbdplus/$version/libbdplus-$version.tar.bz2
       - type: patch
         path: patches/libbdplus-gpg-error.patch
+      - type: patch
+        path: patches/libbdplus-fix-libgcrypt.patch
   - name: libbluray
     config-opts:
       - --disable-static

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -398,8 +398,8 @@ modules:
       - /lib/*.so
     sources:
       - type: archive
-        url: https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-1.0.2.tar.gz
-        sha512: 7092f307a00ba04b539be79a7c94ddf9b4b6e43343a66da49c6602fa860f77cf7f9017d7e40f9b7400d85a828a503248eb12dd121413aad68133003a20bb2c4a
+        url: https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-1.0.3.tar.gz
+        sha512: 5b57df7a4f3f9e5b7c3fea50231490061cf4ee2aaa13575777942ad51564d5a3f1aaed493d8741f736d390888e95161f71d9f39d2bf61cc2e4958df09b496a07
         x-checker-data:
           type: anitya
           project-id: 1658

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -152,8 +152,8 @@ modules:
       - -DGLM_TEST_ENABLE=OFF
     sources:
       - type: archive
-        url: https://github.com/g-truc/glm/archive/refs/tags/0.9.9.8.tar.gz
-        sha256: 7d508ab72cb5d43227a3711420f06ff99b0a0cb63ee2f93631b162bfe1fe9592
+        url: https://github.com/g-truc/glm/archive/refs/tags/1.0.3.tar.gz
+        sha256: 6775e47231a446fd086d660ecc18bcd076531cfedd912fbd66e576b118607001
         x-checker-data:
           type: anitya
           project-id: 1181
@@ -172,7 +172,7 @@ modules:
             >> glm/CMakeLists.txt
           - echo 'install(FILES ${SIMD_HEADER} ${SIMD_INLINE} DESTINATION include/glm/simd)'
             >> glm/CMakeLists.txt
-          - echo 'install(TARGETS glm_static)' >> glm/CMakeLists.txt
+          - echo 'install(TARGETS glm)' >> glm/CMakeLists.txt
   - name: hwdata
     config-opts:
       - --datarootdir=${FLATPAK_DEST}/lib/

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -558,6 +558,7 @@ modules:
     buildsystem: autotools
     config-opts:
       - --prefix=/app
+      - --libdir=/app/lib
       - --disable-python
       - --without-ads
       - --without-ldap
@@ -576,8 +577,8 @@ modules:
       - /lib/*.so
     sources:
       - type: archive
-        url: https://samba.org/samba/ftp/stable/samba-4.22.6.tar.gz
-        sha256: 8e6beb0cce87fb3c763af94c2dc21fd47b8fd02d46b3cb1deb2a72df9259c425
+        url: https://download.samba.org/pub/samba/stable/samba-4.24.0.tar.gz
+        sha256: 1b1e457fd651a612cd08226cc6efd04e5d01e36d918c8b4c4e470e74e86881ea
         x-checker-data:
           type: anitya
           project-id: 4758

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -328,12 +328,12 @@ modules:
       - /lib/*.so
     sources:
       - type: archive
-        url: https://github.com/libcdio/libcdio/releases/download/2.2.0/libcdio-2.2.0.tar.gz
-        sha256: 1b6c58137f71721ddb78773432d26252ee6500d92d227d4c4892631c30ea7abb
+        url: https://github.com/libcdio/libcdio/releases/download/2.3.0/libcdio-2.3.0.tar.bz2
+        sha256: 53e83d284667535a767fd2d31edad1a6701591960459df373a10f1f21e80a7ed
         x-checker-data:
           type: anitya
           project-id: 1573
-          url-template: https://github.com/libcdio/libcdio/releases/download/$version/libcdio-$version.tar.gz
+          url-template: https://github.com/libcdio/libcdio/releases/download/$version/libcdio-$version.tar.bz2
   - name: libcec
     buildsystem: cmake-ninja
     cleanup:


### PR DESCRIPTION
- updates glm and closes https://github.com/flathub/tv.kodi.Kodi/pull/632 & https://github.com/flathub/tv.kodi.Kodi/pull/589
- update samba and close https://github.com/flathub/tv.kodi.Kodi/pull/593
- updates libgcrypt (and adds libgpg-error as a dependency) and libssh to avoid failure to obtain upstream
- adapts libaacs and libbdplus to new libgcrypt version
- removes glu - needed only for wii support which isn't enabled
- updates hwdata, libmicrohttpd to new minor upstream versions
- gamelibretro raw CMakeLists.txt assets were modified upstream, update hashsums
- jsoncpp: update to 1.9.7
- libcdio: update to 2.3.0

Briefly runtested on x86