### PR TITLE
beta updates

### DIFF
--- a/addons/game.libretro/game.libretro.json
+++ b/addons/game.libretro/game.libretro.json
@@ -23,30 +23,6 @@
     ],
     "modules": [
         {
-            "name": "tinyxml",
-            "cleanup": [
-                "/include",
-                "/share/doc",
-                "*.a",
-                "*.la",
-                "/lib/*.so"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "http://mirrors.kodi.tv/build-deps/sources/tinyxml-2.6.2_2.tar.gz",
-                    "sha256": "8164c9ad48b9028667768a584d62f7760cfbfb90d0dd6214ad174403058da10c"
-                },
-                {
-                    "type": "script",
-                    "dest-filename": "autogen.sh",
-                    "commands": [
-                        "autoreconf -vfi"
-                    ]
-                }
-            ]
-        },
-        {
             "name": "libretro-common",
             "buildsystem": "cmake-ninja",
             "build-options": {

--- a/addons/game.libretro/game.libretro.json
+++ b/addons/game.libretro/game.libretro.json
@@ -57,8 +57,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/libretro/libretro-common/archive/ad9124f1ecc5d0092fd285cbf9c4ffac317b1a65.tar.gz",
-                    "sha256": "e8261fb72c107351d433f921e6a383df5f1e7fe6936fb53c8c0e439821dbf175"
+                    "url": "https://github.com/libretro/libretro-common/archive/a08b2b574787408abbb4ba34faf673117f9a0eae.tar.gz",
+                    "sha256": "448c6531e32783835fc900e1dffcf621ad2d0e29134f1e6645e2ee2a3132038f"
                 },
                 {
                     "type": "file",

--- a/addons/inputstream.ffmpegdirect/inputstream.ffmpegdirect.json
+++ b/addons/inputstream.ffmpegdirect/inputstream.ffmpegdirect.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/inputstream.ffmpegdirect",
-            "commit": "527a71baa23a81e79b7ee2b1a658e73b54339978"
+            "commit": "8aa4d3730dba887d2f0ae57700cfb78a601de5a4"
         }
     ],
     "build-options": {

--- a/addons/pvr.argustv/pvr.argustv.json
+++ b/addons/pvr.argustv/pvr.argustv.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.argustv",
-            "commit": "e55346d02306f3e500ab689f84965621dfb71ba7"
+            "commit": "698f8712c3172f2b15890e486d49896f71826043"
         }
     ],
     "build-options": {

--- a/addons/pvr.demo/pvr.demo.json
+++ b/addons/pvr.demo/pvr.demo.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.demo",
-            "commit": "944f4c65bec3b76c88d8129910a5d616b77619a1"
+            "commit": "2b422a9071c8e31acea21cadd57838f58b6613a0"
         }
     ],
     "build-options": {

--- a/addons/pvr.dvblink/pvr.dvblink.json
+++ b/addons/pvr.dvblink/pvr.dvblink.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.dvblink",
-            "commit": "f05ec0e828a34babccb99c1d758e1e57a9abeb01"
+            "commit": "6eb305fdec76e1da883f67b8133f67962d84a64b"
         }
     ],
     "build-options": {

--- a/addons/pvr.dvbviewer/pvr.dvbviewer.json
+++ b/addons/pvr.dvbviewer/pvr.dvbviewer.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.dvbviewer",
-            "commit": "839b28fa591a2a09b9103ade37ea830bad0a6c7c"
+            "commit": "ee4863a0f4b0f648ed99e263e280bafe499438bb"
         }
     ],
     "build-options": {

--- a/addons/pvr.hts/pvr.hts.json
+++ b/addons/pvr.hts/pvr.hts.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.hts",
-            "commit": "7a45b317a6b746703ba173877412f711ddfa0d98"
+            "commit": "fa4885098bb86a398fc04392c6ee3be8c1f76822"
         }
     ],
     "build-options": {

--- a/addons/pvr.iptvsimple/pvr.iptvsimple.json
+++ b/addons/pvr.iptvsimple/pvr.iptvsimple.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.iptvsimple",
-            "commit": "739177cad2de291a70175b76e79f0ce16688c0da"
+            "commit": "5c235d5cd04b00f9656a387b3fe42896873b295b"
         }
     ],
     "build-options": {

--- a/addons/pvr.mythtv/pvr.mythtv.json
+++ b/addons/pvr.mythtv/pvr.mythtv.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/janbar/pvr.mythtv",
-            "commit": "883f91737d4e75cf0aa5cdb22970190dee05e722"
+            "commit": "968dee1479edb5acdc21cffc5e829fdba2152097"
         }
     ],
     "build-options": {

--- a/addons/pvr.nextpvr/pvr.nextpvr.json
+++ b/addons/pvr.nextpvr/pvr.nextpvr.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.nextpvr",
-            "commit": "b868201bcd06134f48d9ee4c5ee9b1bdf2e4c842"
+            "commit": "5e493569098441ea2f18a8058ccc64eac59d8717"
         }
     ],
     "build-options": {

--- a/addons/pvr.stalker/pvr.stalker.json
+++ b/addons/pvr.stalker/pvr.stalker.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.stalker",
-            "commit": "fa558f8aa869b51b42895c0ff53826a83789afb6"
+            "commit": "1f564e2345db6b44433fc583d58f8edf4131d318"
         }
     ],
     "build-options": {

--- a/addons/pvr.vdr.vnsi/pvr.vdr.vnsi.json
+++ b/addons/pvr.vdr.vnsi/pvr.vdr.vnsi.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.vdr.vnsi",
-            "commit": "35a8542898716c85641ef560ee3505b123124d9c"
+            "commit": "178f32fa77d55f9fbdf26287e44f82eb4375fb25"
         }
     ],
     "build-options": {

--- a/addons/pvr.vuplus/pvr.vuplus.json
+++ b/addons/pvr.vuplus/pvr.vuplus.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.vuplus",
-            "commit": "dfc5fa3078a020f9842ce63a110c5a92d3e137cc"
+            "commit": "04f5e0de300586f1e825779ea2a178097099410b"
         }
     ],
     "build-options": {

--- a/addons/pvr.waipu/pvr.waipu.json
+++ b/addons/pvr.waipu/pvr.waipu.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/flubshi/pvr.waipu",
-            "commit": "ee0f22529e6b7c508c745abb89f76d502a34fa8e"
+            "commit": "8cc35d716eab041151b9dbcdbf99f27aab7f6a30"
         }
     ],
     "build-options": {

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -101,8 +101,8 @@ modules:
       - /lib/*.so
     sources:
       - type: archive
-        url: https://github.com/google/flatbuffers/archive/refs/tags/v25.12.19.tar.gz
-        sha512: 808c77536fbfb1c8a1145506873a2b4e5cb508e48bf35f8502a2d1349b64e7581bfe7ff2f587b3edb2642cc885c60c0170a8875fad245240a1288057f4c07a42
+        url: https://github.com/google/flatbuffers/archive/refs/tags/v25.12.19-2026-02-06-03fffb2.tar.gz
+        sha512: 61d71f830a249d16e5d9e3d7ffde40b123bddc3824c3431aeedc3c19eb9913ca5c6ae4d509a65824242b50b363037cd9d5b084170e4719d8b24762c13be054c4
         x-checker-data:
           type: anitya
           project-id: 16642

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -577,8 +577,8 @@ modules:
           - --enable-compat-libdns_sd
         sources:
           - type: archive
-            url: https://github.com/avahi/avahi/archive/refs/tags/v0.9-rc3.tar.gz
-            sha256: 9f2ff92864c56364d711eb2acec4c0455d1375d8c3266e420611730a2c9ccba5
+            url: https://github.com/avahi/avahi/archive/refs/tags/v0.9-rc4.tar.gz
+            sha256: 08fcc57377ed05416ec4b3d8a179da716a7a9376821551a5ae16f8276a1ef0b5
             x-checker-data:
               type: anitya
               project-id: 147

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -762,7 +762,7 @@ modules:
       - type: git
         url: https://github.com/xbmc/xbmc.git
         #tag: 22.0a3-Piers
-        commit: 364219ea7cb01c1ee627c56c88c0178d310505a1
+        commit: 2468ae154860790300e8d5af4b99c01549aa6d1b
         x-checker-data:
           type: git
           tag-pattern: ^([\d.]+)-\w+$

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -361,8 +361,8 @@ modules:
       - /lib/*.so
     sources:
       - type: archive
-        url: https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-1.0.3.tar.gz
-        sha512: 5b57df7a4f3f9e5b7c3fea50231490061cf4ee2aaa13575777942ad51564d5a3f1aaed493d8741f736d390888e95161f71d9f39d2bf61cc2e4958df09b496a07
+        url: https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-1.0.4.tar.gz
+        sha256: d72e5cfccd62bf2f79252edbc3828eeedc088ce71fc47b7c9e3bd7246b3d54de
         x-checker-data:
           type: anitya
           project-id: 1658


### PR DESCRIPTION
- kodi: update to githash 2468ae1
- global addons update
- game.libretro: drop dup tinyxml already defined in base manifest
- game.libretro: update libretro-common to githash a08b2b5 (fixes: CVE-2025-9809)
- flatbuffers: update to 25.12.19-2026-02-06-03fffb2
- avahi: update to 0.9-rc4
- libmicrohttpd: update to 1.0.4
