### PR TITLE
beta updates

### DIFF
--- a/addons/inputstream.adaptive/inputstream.adaptive.json
+++ b/addons/inputstream.adaptive/inputstream.adaptive.json
@@ -11,7 +11,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/inputstream.adaptive",
-            "commit": "097a80fa07f04efa9b3687887b4fdf008a076f14"
+            "commit": "f6deb2e9c480e14a9acef85d8c32a607766d83a0"
         },
         {
             "type": "file",

--- a/addons/pvr.nextpvr/pvr.nextpvr.json
+++ b/addons/pvr.nextpvr/pvr.nextpvr.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.nextpvr",
-            "commit": "b3af5125eac055ac88d526d5f3d9e08c2ec337d5"
+            "commit": "bfa8e9665e22ec30cf451dc32008300990d0b8bd"
         }
     ],
     "build-options": {

--- a/addons/pvr.vuplus/pvr.vuplus.json
+++ b/addons/pvr.vuplus/pvr.vuplus.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.vuplus",
-            "commit": "04f5e0de300586f1e825779ea2a178097099410b"
+            "commit": "30efd53d5934e503a1168a64193b51d7ff1f42c0"
         }
     ],
     "build-options": {

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -3,7 +3,7 @@ runtime: org.freedesktop.Platform
 runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.openjdk25
+  - org.freedesktop.Sdk.Extension.openjdk17
 command: kodi
 rename-icon: kodi
 rename-desktop-file: kodi.desktop
@@ -750,7 +750,7 @@ modules:
       - -DDISABLE_FFMPEG_SOURCE_PLUGINS=ON
       - -DDEPENDS_PATH=/app
       - -DAPP_RENDER_SYSTEM=gl
-      - -DJava_JAVA_EXECUTABLE=/usr/lib/sdk/openjdk25/bin/java
+      - -DJava_JAVA_EXECUTABLE=/usr/lib/sdk/openjdk17/bin/java
       - -DCROSSGUID_URL=build/download/crossguid.tar.gz
       - -DLIBDVDCSS_URL=build/download/libdvdcss.tar.gz
       - -DLIBDVDREAD_URL=build/download/libdvdread.tar.gz


### PR DESCRIPTION
- [Revert "openjdk: update and pin to openjdk25, latest LTS"](https://github.com/flathub/tv.kodi.Kodi/commit/1f53b324e446273bc8ac2887a9018eb6b47b004e) - JDK 17 is the only sane choice until kodi's codegenerator is groovy 5 compatible
- [global addons update](https://github.com/flathub/tv.kodi.Kodi/commit/7c7dbc7ccdebc17535721e076df7fd91704ed16a)