### PR TITLE
[omega test] ffmpeg: update to 7.1.3 and patch kodi + addons

### DIFF
--- a/addons/inputstream.adaptive/inputstream.adaptive.json
+++ b/addons/inputstream.adaptive/inputstream.adaptive.json
@@ -14,6 +14,10 @@
             "commit": "c567d396fba39fc423628531d07e7064315afe00"
         },
         {
+            "type": "patch",
+            "path": "patches/ffmpeg7.patch"
+        },
+        {
             "type": "file",
             "url": "https://github.com/xbmc/Bento4/archive/refs/tags/1.6.0-641-3-Omega.tar.gz",
             "sha256": "a9b231b63159b3a4d9e47c5328b476308852bf092ccb9ce98f7cf46a386465ce",

--- a/addons/inputstream.adaptive/patches/ffmpeg7.patch
+++ b/addons/inputstream.adaptive/patches/ffmpeg7.patch
@@ -1,0 +1,46 @@
+From 5b0c63b51bf9482004c44c243d3e0605c15f6b29 Mon Sep 17 00:00:00 2001
+From: CastagnaIT <gottardo.stefano.83@gmail.com>
+Date: Sun, 22 Dec 2024 11:25:42 +0100
+Subject: [PATCH] [Session] Set Atmos profile instead of JOC codec string
+
+Since has been merged ffmpeg 7.1 in to kodi core
+the string "eac3-joc" is no longer recognized as a workaround to display the atmos profile in the GUI
+but in its place the atmos codec profile is now working
+---
+ src/Session.cpp   | 7 +++----
+ src/utils/Utils.h | 2 +-
+ 2 files changed, 4 insertions(+), 5 deletions(-)
+
+diff --git a/src/Session.cpp b/src/Session.cpp
+index 0593fa34f..abbf7cb5a 100644
+--- a/src/Session.cpp
++++ b/src/Session.cpp
+@@ -819,12 +819,11 @@ void SESSION::CSession::UpdateStream(CStream& stream)
+       stream.m_info.SetCodecName(CODEC::NAME_DTS);
+     else if (CODEC::Contains(codecs, CODEC::FOURCC_AC_3, codecStr))
+       stream.m_info.SetCodecName(CODEC::NAME_AC3);
+-    else if (CODEC::Contains(codecs, CODEC::NAME_EAC3_JOC, codecStr) ||
+-             CODEC::Contains(codecs, CODEC::FOURCC_EC_3, codecStr))
++    else if (CODEC::Contains(codecs, CODEC::FOURCC_EC_3, codecStr))
+     {
+-      // In the above condition above is checked NAME_EAC3_JOC as first,
+-      // in order to get the codec string to signal DD+ Atmos in to the SetCodecInternalName
+       stream.m_info.SetCodecName(CODEC::NAME_EAC3);
++      if (CODEC::Contains(codecs, CODEC::NAME_EAC3_JOC))
++        stream.m_info.SetCodecProfile(STREAMCODEC_PROFILE::DDPlusCodecProfileAtmos);
+     }
+     else if (CODEC::Contains(codecs, CODEC::FOURCC_OPUS, codecStr))
+       stream.m_info.SetCodecName(CODEC::NAME_OPUS);
+diff --git a/src/utils/Utils.h b/src/utils/Utils.h
+index 2ab8de8eb..9001fca38 100644
+--- a/src/utils/Utils.h
++++ b/src/utils/Utils.h
+@@ -59,7 +59,7 @@ namespace CODEC
+ {
+ constexpr const char* NAME_UNKNOWN = "unk"; // Kodi codec name for unknown codec
+ 
+-// Kodi internal codec name to signal DD+ Atmos ("joc"), not a ffmpeg definition
++// ISA internal codec name to signal DD+ Atmos profile ("joc")
+ constexpr const char* NAME_EAC3_JOC = "eac3-joc";
+ 
+ // IMPORTANT: Codec names must match the ffmpeg library definition

--- a/addons/inputstream.ffmpegdirect/inputstream.ffmpegdirect.json
+++ b/addons/inputstream.ffmpegdirect/inputstream.ffmpegdirect.json
@@ -6,6 +6,10 @@
             "type": "git",
             "url": "https://github.com/xbmc/inputstream.ffmpegdirect",
             "commit": "3c596496d2360f7b25ff58886a81cb1273266481"
+        },
+        {
+            "type": "patch",
+            "path": "patches/ffmpeg7.patch"
         }
     ],
     "build-options": {

--- a/addons/inputstream.ffmpegdirect/patches/ffmpeg7.patch
+++ b/addons/inputstream.ffmpegdirect/patches/ffmpeg7.patch
@@ -1,0 +1,227 @@
+From 5552d0bde9ec84c42ef7a72972179f99755a2618 Mon Sep 17 00:00:00 2001
+From: Vasyl Gello <vasek.gello@gmail.com>
+Date: Fri, 9 Aug 2024 07:11:41 +0000
+Subject: [PATCH] Port FFmpeg 7.0 to ffmpegdirect Omega
+
+From https://github.com/xbmc/xbmc/pull/24972
+
+Signed-off-by: Vasyl Gello <vasek.gello@gmail.com>
+---
+ FindFFMPEG.cmake                     |  16 ++--
+ depends/common/ffmpeg/CMakeLists.txt |   4 +-
+ depends/common/ffmpeg/ffmpeg.sha256  |   2 +-
+ depends/common/ffmpeg/ffmpeg.txt     |   2 +-
+ src/stream/FFmpegStream.cpp          | 125 ++++++++-------------------
+ 5 files changed, 46 insertions(+), 103 deletions(-)
+
+diff --git a/FindFFMPEG.cmake b/FindFFMPEG.cmake
+index d03f329..8b20538 100644
+--- a/FindFFMPEG.cmake
++++ b/FindFFMPEG.cmake
+@@ -33,14 +33,14 @@
+ #
+ 
+ # required ffmpeg library versions
+-set(REQUIRED_FFMPEG_VERSION 5.0.0)
+-set(_avcodec_ver ">=59.18.100")
+-set(_avfilter_ver ">=8.24.100")
+-set(_avformat_ver ">=59.16.100")
+-set(_avutil_ver ">=57.17.100")
+-set(_postproc_ver ">=56.3.100")
+-set(_swresample_ver ">=4.3.100")
+-set(_swscale_ver ">=6.4.100")
++set(REQUIRED_FFMPEG_VERSION 7.0.0)
++set(_avcodec_ver ">=61.3.100")
++set(_avfilter_ver ">=10.1.100")
++set(_avformat_ver ">=61.1.100")
++set(_avutil_ver ">=59.8.100")
++set(_postproc_ver ">=58.1.100")
++set(_swresample_ver ">=5.1.100")
++set(_swscale_ver ">=8.1.100")
+ 
+ # Allows building with external ffmpeg not found in system paths,
+ # without library version checks
+diff --git a/src/stream/FFmpegStream.cpp b/src/stream/FFmpegStream.cpp
+index 8bf474f..c77e09d 100644
+--- a/src/stream/FFmpegStream.cpp
++++ b/src/stream/FFmpegStream.cpp
+@@ -1012,74 +1012,7 @@ bool FFmpegStream::OpenWithCURL(const AVInputFormat* iformat)
+   if (iformat == nullptr)
+   {
+     // let ffmpeg decide which demuxer we have to open
+-    bool trySPDIFonly = (m_curlInput->GetContent() == "audio/x-spdif-compressed");
+-
+-    if (!trySPDIFonly)
+-      av_probe_input_buffer(m_ioContext, &iformat, strFile.c_str(), NULL, 0, 0);
+-
+-    // Use the more low-level code in case we have been built against an old
+-    // FFmpeg without the above av_probe_input_buffer(), or in case we only
+-    // want to probe for spdif (DTS or IEC 61937) compressed audio
+-    // specifically, or in case the file is a wav which may contain DTS or
+-    // IEC 61937 (e.g. ac3-in-wav) and we want to check for those formats.
+-    if (trySPDIFonly || (iformat && strcmp(iformat->name, "wav") == 0))
+-    {
+-      AVProbeData pd;
+-      int probeBufferSize = 32768;
+-      std::unique_ptr<uint8_t[]> probe_buffer (new uint8_t[probeBufferSize + AVPROBE_PADDING_SIZE]);
+-
+-      // init probe data
+-      pd.buf = probe_buffer.get();
+-      pd.filename = strFile.c_str();
+-
+-      // read data using avformat's buffers
+-      pd.buf_size = avio_read(m_ioContext, pd.buf, probeBufferSize);
+-      if (pd.buf_size <= 0)
+-      {
+-        Log(LOGLEVEL_ERROR, "%s - error reading from input stream, %s", __FUNCTION__, CURL::GetRedacted(strFile).c_str());
+-        return false;
+-      }
+-      memset(pd.buf + pd.buf_size, 0, AVPROBE_PADDING_SIZE);
+-
+-      // restore position again
+-      avio_seek(m_ioContext , 0, SEEK_SET);
+-
+-      // the advancedsetting is for allowing the user to force outputting the
+-      // 44.1 kHz DTS wav file as PCM, so that an A/V receiver can decode
+-      // it (this is temporary until we handle 44.1 kHz passthrough properly)
+-      if (trySPDIFonly || (iformat && strcmp(iformat->name, "wav") == 0)) // && !CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_VideoPlayerIgnoreDTSinWAV))
+-      {
+-        // check for spdif and dts
+-        // This is used with wav files and audio CDs that may contain
+-        // a DTS or AC3 track padded for S/PDIF playback. If neither of those
+-        // is present, we assume it is PCM audio.
+-        // AC3 is always wrapped in iec61937 (ffmpeg "spdif"), while DTS
+-        // may be just padded.
+-        const AVInputFormat* iformat2 = av_find_input_format("spdif");
+-
+-        if (iformat2 && iformat2->read_probe(&pd) > AVPROBE_SCORE_MAX / 4)
+-        {
+-          iformat = iformat2;
+-        }
+-        else
+-        {
+-          // not spdif or no spdif demuxer, try dts
+-          iformat2 = av_find_input_format("dts");
+-
+-          if (iformat2 && iformat2->read_probe(&pd) > AVPROBE_SCORE_MAX / 4)
+-          {
+-            iformat = iformat2;
+-          }
+-          else if (trySPDIFonly)
+-          {
+-            // not dts either, return false in case we were explicitly
+-            // requested to only check for S/PDIF padded compressed audio
+-            Log(LOGLEVEL_DEBUG, "%s - not spdif or dts file, falling back", __FUNCTION__);
+-            return false;
+-          }
+-        }
+-      }
+-    }
++    av_probe_input_buffer(m_ioContext, &iformat, strFile.c_str(), NULL, 0, 0);
+ 
+     if (!iformat)
+     {
+@@ -1535,7 +1468,7 @@ bool FFmpegStream::SeekTime(double time, bool backwards, double* startpts)
+ 
+     if (ret >= 0)
+     {
+-      if (m_pFormatContext->iformat->read_seek)
++      if (!(m_pFormatContext->iformat->flags & AVFMT_NOTIMESTAMPS))
+         m_seekToKeyFrame = true;
+ 
+         m_currentPts = STREAM_NOPTS_VALUE;
+@@ -2059,43 +1992,49 @@ DemuxStream* FFmpegStream::AddStream(int streamIdx)
+         st->colorRange = pStream->codecpar->color_range;
+         st->hdr_type = DetermineHdrType(pStream);
+ 
+-        // https://github.com/FFmpeg/FFmpeg/blob/release/5.0/doc/APIchanges
+-        size_t size = 0;
+-        uint8_t* side_data = nullptr;
++        // https://github.com/FFmpeg/FFmpeg/blob/release/7.0/doc/APIchanges
++        const AVPacketSideData* sideData = nullptr;
+ 
+         if (st->hdr_type == StreamHdrType::HDR_TYPE_DOLBYVISION)
+         {
+-          side_data = av_stream_get_side_data(pStream, AV_PKT_DATA_DOVI_CONF, &size);
+-          if (side_data && size)
++
++          sideData =
++              av_packet_side_data_get(pStream->codecpar->coded_side_data,
++                                      pStream->codecpar->nb_coded_side_data, AV_PKT_DATA_DOVI_CONF);
++          if (sideData && sideData->size)
+           {
+-            st->dovi = *reinterpret_cast<AVDOVIDecoderConfigurationRecord*>(side_data);
++            st->dovi = *reinterpret_cast<const AVDOVIDecoderConfigurationRecord*>(sideData->data);
+           }
+         }
+ 
+-        side_data = av_stream_get_side_data(pStream, AV_PKT_DATA_MASTERING_DISPLAY_METADATA, &size);
+-        if (side_data && size)
++        sideData = av_packet_side_data_get(pStream->codecpar->coded_side_data,
++                                           pStream->codecpar->nb_coded_side_data,
++                                           AV_PKT_DATA_MASTERING_DISPLAY_METADATA);
++        if (sideData && sideData->size)
+         {
+           st->masteringMetaData = std::make_shared<AVMasteringDisplayMetadata>(
+-              *reinterpret_cast<AVMasteringDisplayMetadata*>(side_data));
++              *reinterpret_cast<const AVMasteringDisplayMetadata*>(sideData->data));
+         }
+ 
+-        side_data = av_stream_get_side_data(pStream, AV_PKT_DATA_CONTENT_LIGHT_LEVEL, &size);
+-        if (side_data && size)
++        sideData = av_packet_side_data_get(pStream->codecpar->coded_side_data,
++                                           pStream->codecpar->nb_coded_side_data,
++                                           AV_PKT_DATA_CONTENT_LIGHT_LEVEL);
++        if (sideData && sideData->size)
+         {
+           st->contentLightMetaData = std::make_shared<AVContentLightMetadata>(
+-              *reinterpret_cast<AVContentLightMetadata*>(side_data));
++              *reinterpret_cast<const AVContentLightMetadata*>(sideData->data));
+         }
+ 
+-        AVDictionaryEntry* rtag = av_dict_get(pStream->metadata, "rotate", NULL, 0);
+-        uint8_t* displayMatrixSideData =
+-            av_stream_get_side_data(pStream, AV_PKT_DATA_DISPLAYMATRIX, nullptr);
+-        if (displayMatrixSideData)
++        sideData = av_packet_side_data_get(pStream->codecpar->coded_side_data,
++                                           pStream->codecpar->nb_coded_side_data,
++                                           AV_PKT_DATA_DISPLAYMATRIX);
++        if (sideData)
+         {
+-          const double tetha =
+-              av_display_rotation_get(reinterpret_cast<int32_t*>(displayMatrixSideData));
+-          if (!std::isnan(tetha))
++          const double theta =
++              av_display_rotation_get(reinterpret_cast<const int32_t*>(sideData->data));
++          if (!std::isnan(theta))
+           {
+-            st->iOrientation = ((static_cast<int>(-tetha) % 360) + 360) % 360;
++            st->iOrientation = ((static_cast<int>(-theta) % 360) + 360) % 360;
+           }
+         }
+ 
+@@ -2271,7 +2210,9 @@ StreamHdrType FFmpegStream::DetermineHdrType(AVStream* pStream)
+ {
+   StreamHdrType hdrType = StreamHdrType::HDR_TYPE_NONE;
+ 
+-  if (av_stream_get_side_data(pStream, AV_PKT_DATA_DOVI_CONF, nullptr)) // DoVi
++  if (av_packet_side_data_get(pStream->codecpar->coded_side_data,
++                              pStream->codecpar->nb_coded_side_data,
++                              AV_PKT_DATA_DOVI_CONF)) // DoVi
+     hdrType = StreamHdrType::HDR_TYPE_DOLBYVISION;
+   else if (pStream->codecpar->color_trc == AVCOL_TRC_SMPTE2084) // HDR10
+     hdrType = StreamHdrType::HDR_TYPE_HDR10;
+@@ -2279,7 +2220,9 @@ StreamHdrType FFmpegStream::DetermineHdrType(AVStream* pStream)
+     hdrType = StreamHdrType::HDR_TYPE_HLG;
+   // file could be SMPTE2086 which FFmpeg currently returns as unknown
+   // so use the presence of static metadata to detect it
+-  else if (av_stream_get_side_data(pStream, AV_PKT_DATA_MASTERING_DISPLAY_METADATA, nullptr))
++  else if (av_packet_side_data_get(pStream->codecpar->coded_side_data,
++                                   pStream->codecpar->nb_coded_side_data,
++                                   AV_PKT_DATA_MASTERING_DISPLAY_METADATA))
+     hdrType = StreamHdrType::HDR_TYPE_HDR10;
+ 
+   return hdrType;
+-- 
+2.43.0
+

--- a/patches/ffmpeg7.patch
+++ b/patches/ffmpeg7.patch
@@ -1,0 +1,745 @@
+From 5f731d1c62ebee57c0a545fe255c53b8018ca754 Mon Sep 17 00:00:00 2001
+From: Stephan Sundermann <stephansundermann@gmail.com>
+Date: Thu, 11 Apr 2024 17:11:32 +0200
+Subject: [PATCH 1/7] [ffmpeg] Update to 7.0
+
+---
+ cmake/modules/FindFFMPEG.cmake                |  16 +--
+ tools/buildsteps/windows/ffmpeg_options.txt   |   1 -
+ tools/depends/target/ffmpeg/CMakeLists.txt    |   6 +-
+ tools/depends/target/ffmpeg/FFMPEG-VERSION    |   4 +-
+ xbmc/cdrip/EncoderFFmpeg.cpp                  |   2 +-
+ xbmc/cdrip/EncoderFFmpeg.h                    |   2 +-
+ .../ActiveAE/ActiveAEResampleFFMPEG.cpp       | 110 +++++++++---------
+ .../DVDDemuxers/DVDDemuxFFmpeg.cpp            |  71 +----------
+ 8 files changed, 69 insertions(+), 143 deletions(-)
+
+diff --git a/cmake/modules/FindFFMPEG.cmake b/cmake/modules/FindFFMPEG.cmake
+index 6c6bf973de..6bd05e9f3d 100644
+--- a/cmake/modules/FindFFMPEG.cmake
++++ b/cmake/modules/FindFFMPEG.cmake
+@@ -163,14 +163,14 @@ if(WITH_FFMPEG)
+   set(REQUIRED_FFMPEG_VERSION undef)
+ else()
+   # required ffmpeg library versions
+-  set(REQUIRED_FFMPEG_VERSION 6.0.0)
+-  set(_avcodec_ver ">=60.2.100")
+-  set(_avfilter_ver ">=9.3.100")
+-  set(_avformat_ver ">=60.3.100")
+-  set(_avutil_ver ">=58.2.100")
+-  set(_postproc_ver ">=57.1.100")
+-  set(_swresample_ver ">=4.10.100")
+-  set(_swscale_ver ">=7.1.100")
++  set(REQUIRED_FFMPEG_VERSION 7.0.0)
++  set(_avcodec_ver ">=61.3.100")
++  set(_avfilter_ver ">=10.1.100")
++  set(_avformat_ver ">=61.1.100")
++  set(_avutil_ver ">=59.8.100")
++  set(_postproc_ver ">=58.1.100")
++  set(_swresample_ver ">=5.1.100")
++  set(_swscale_ver ">=8.1.100")
+ endif()
+ 
+ # Allows building with external ffmpeg not found in system paths,
+diff --git a/tools/buildsteps/windows/ffmpeg_options.txt b/tools/buildsteps/windows/ffmpeg_options.txt
+index 5034ff26c4..776c0b4b35 100644
+--- a/tools/buildsteps/windows/ffmpeg_options.txt
++++ b/tools/buildsteps/windows/ffmpeg_options.txt
+@@ -1,5 +1,4 @@
+ --disable-avdevice
+---disable-crystalhd
+ --disable-cuda
+ --disable-cuvid
+ --disable-devices
+diff --git a/tools/depends/target/ffmpeg/FFMPEG-VERSION b/tools/depends/target/ffmpeg/FFMPEG-VERSION
+index f2ba09402e..60b8887de3 100644
+--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
++++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
+@@ -1,5 +1,5 @@
+ LIBNAME=ffmpeg
+-VERSION=6.0.1
++VERSION=7.0.1
+ ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
+-SHA512=945e34840092dc0fd3824eb1af2be79868af2afb4fe13159b19a9bcfc464cc4d53243c13ff065199290e9393ddbf4b1c5c8abccf83a31a31d6c7490e499fd1fc
++SHA512=43b639b0bc0597e95dea2dce3e925f4b71ca8c4d9eadaef614941053e287f2d5c2e78d95413f0f7142da0f6ea1dbf443457e4fa1c2296cd8cf4081c185ed9c04
+ 
+diff --git a/xbmc/cdrip/EncoderFFmpeg.cpp b/xbmc/cdrip/EncoderFFmpeg.cpp
+index 85f5fa412e..907d2591dd 100644
+--- a/xbmc/cdrip/EncoderFFmpeg.cpp
++++ b/xbmc/cdrip/EncoderFFmpeg.cpp
+@@ -235,7 +235,7 @@ void CEncoderFFmpeg::SetTag(const std::string& tag, const std::string& value)
+   av_dict_set(&m_formatCtx->metadata, tag.c_str(), value.c_str(), 0);
+ }
+ 
+-int CEncoderFFmpeg::avio_write_callback(void* opaque, uint8_t* buf, int buf_size)
++int CEncoderFFmpeg::avio_write_callback(void* opaque, const uint8_t* buf, int buf_size)
+ {
+   CEncoderFFmpeg* enc = static_cast<CEncoderFFmpeg*>(opaque);
+   if (enc->Write(buf, buf_size) != buf_size)
+diff --git a/xbmc/cdrip/EncoderFFmpeg.h b/xbmc/cdrip/EncoderFFmpeg.h
+index 48471a4b10..4e9f0f5bbb 100644
+--- a/xbmc/cdrip/EncoderFFmpeg.h
++++ b/xbmc/cdrip/EncoderFFmpeg.h
+@@ -33,7 +33,7 @@ public:
+   bool Close() override;
+ 
+ private:
+-  static int avio_write_callback(void* opaque, uint8_t* buf, int buf_size);
++  static int avio_write_callback(void* opaque, const uint8_t* buf, int buf_size);
+   static int64_t avio_seek_callback(void* opaque, int64_t offset, int whence);
+ 
+   void SetTag(const std::string& tag, const std::string& value);
+diff --git a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResampleFFMPEG.cpp b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResampleFFMPEG.cpp
+index e897cbd3ea..6fce0af981 100644
+--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResampleFFMPEG.cpp
++++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResampleFFMPEG.cpp
+@@ -66,51 +66,7 @@ bool CActiveAEResampleFFMPEG::Init(SampleConfig dstConfig, SampleConfig srcConfi
+   AVChannelLayout dstChLayout = {};
+   AVChannelLayout srcChLayout = {};
+ 
+-  av_channel_layout_from_mask(&dstChLayout, m_dst_chan_layout);
+-  av_channel_layout_from_mask(&srcChLayout, m_src_chan_layout);
+-
+-  int ret = swr_alloc_set_opts2(&m_pContext, &dstChLayout, m_dst_fmt, m_dst_rate, &srcChLayout,
+-                                m_src_fmt, m_src_rate, 0, NULL);
+-
+-  if (ret)
+-  {
+-    CLog::Log(LOGERROR, "CActiveAEResampleFFMPEG::Init - create context failed");
+-    return false;
+-  }
+-
+-  if(quality == AE_QUALITY_HIGH)
+-  {
+-    av_opt_set_double(m_pContext, "cutoff", 1.0, 0);
+-    av_opt_set_int(m_pContext,"filter_size", 256, 0);
+-  }
+-  else if(quality == AE_QUALITY_MID)
+-  {
+-    // 0.97 is default cutoff so use (1.0 - 0.97) / 2.0 + 0.97
+-    av_opt_set_double(m_pContext, "cutoff", 0.985, 0);
+-    av_opt_set_int(m_pContext,"filter_size", 64, 0);
+-  }
+-  else if(quality == AE_QUALITY_LOW)
+-  {
+-    av_opt_set_double(m_pContext, "cutoff", 0.97, 0);
+-    av_opt_set_int(m_pContext,"filter_size", 32, 0);
+-  }
+-
+-  if (m_dst_fmt == AV_SAMPLE_FMT_S32 || m_dst_fmt == AV_SAMPLE_FMT_S32P)
+-  {
+-    av_opt_set_int(m_pContext, "output_sample_bits", m_dst_bits, 0);
+-  }
+-
+-  // tell resampler to clamp float values
+-  // not required for sink stage (remapLayout == true)
+-  if ((m_dst_fmt == AV_SAMPLE_FMT_FLT || m_dst_fmt == AV_SAMPLE_FMT_FLTP) &&
+-      (m_src_fmt == AV_SAMPLE_FMT_FLT || m_src_fmt == AV_SAMPLE_FMT_FLTP) &&
+-      !remapLayout && normalize)
+-  {
+-     av_opt_set_double(m_pContext, "rematrix_maxval", 1.0, 0);
+-  }
+-
+-  av_opt_set_double(m_pContext, "center_mix_level", centerMix, 0);
+-
++  bool hasMatrix = false;
+   if (remapLayout)
+   {
+     // one-to-one mapping of channels
+@@ -120,28 +76,19 @@ bool CActiveAEResampleFFMPEG::Init(SampleConfig dstConfig, SampleConfig srcConfi
+     m_dst_chan_layout = 0;
+     for (unsigned int out=0; out<remapLayout->Count(); out++)
+     {
+-      m_dst_chan_layout += ((uint64_t)1) << out;
++      m_dst_chan_layout += static_cast<uint64_t>(1) << out;
+       int idx = CAEUtil::GetAVChannelIndex((*remapLayout)[out], m_src_chan_layout);
+       if (idx >= 0)
+       {
+         m_rematrix[out][idx] = 1.0;
+       }
+     }
+-
+-    av_opt_set_int(m_pContext, "out_channel_count", m_dst_channels, 0);
+-    av_opt_set_int(m_pContext, "out_channel_layout", m_dst_chan_layout, 0);
+-
+-    if (swr_set_matrix(m_pContext, (const double*)m_rematrix, AE_CH_MAX) < 0)
+-    {
+-      CLog::Log(LOGERROR, "CActiveAEResampleFFMPEG::Init - setting channel matrix failed");
+-      return false;
+-    }
++    hasMatrix = true;
+   }
+   // stereo upmix
+   else if (upmix && m_src_channels == 2 && m_dst_channels > 2)
+   {
+     memset(m_rematrix, 0, sizeof(m_rematrix));
+-    av_channel_layout_uninit(&dstChLayout);
+     av_channel_layout_from_mask(&dstChLayout, m_dst_chan_layout);
+     for (int out=0; out<m_dst_channels; out++)
+     {
+@@ -171,15 +118,64 @@ bool CActiveAEResampleFFMPEG::Init(SampleConfig dstConfig, SampleConfig srcConfi
+       }
+     }
+ 
++    hasMatrix = true;
+     av_channel_layout_uninit(&dstChLayout);
++  }
++
++  av_channel_layout_from_mask(&dstChLayout, m_dst_chan_layout);
++  av_channel_layout_from_mask(&srcChLayout, m_src_chan_layout);
++
++  int ret = swr_alloc_set_opts2(&m_pContext, &dstChLayout, m_dst_fmt, m_dst_rate, &srcChLayout,
++                                m_src_fmt, m_src_rate, 0, NULL);
++
++  if (ret)
++  {
++    CLog::Log(LOGERROR, "CActiveAEResampleFFMPEG::Init - create context failed");
++    return false;
++  }
+ 
+-    if (swr_set_matrix(m_pContext, (const double*)m_rematrix, AE_CH_MAX) < 0)
++  if (hasMatrix)
++  {
++    if (swr_set_matrix(m_pContext, reinterpret_cast<const double*>(m_rematrix), AE_CH_MAX) < 0)
+     {
+       CLog::Log(LOGERROR, "CActiveAEResampleFFMPEG::Init - setting channel matrix failed");
+       return false;
+     }
+   }
+ 
++  if (quality == AE_QUALITY_HIGH)
++  {
++    av_opt_set_double(m_pContext, "cutoff", 1.0, 0);
++    av_opt_set_int(m_pContext, "filter_size", 256, 0);
++  }
++  else if (quality == AE_QUALITY_MID)
++  {
++    // 0.97 is default cutoff so use (1.0 - 0.97) / 2.0 + 0.97
++    av_opt_set_double(m_pContext, "cutoff", 0.985, 0);
++    av_opt_set_int(m_pContext, "filter_size", 64, 0);
++  }
++  else if (quality == AE_QUALITY_LOW)
++  {
++    av_opt_set_double(m_pContext, "cutoff", 0.97, 0);
++    av_opt_set_int(m_pContext, "filter_size", 32, 0);
++  }
++
++  if (m_dst_fmt == AV_SAMPLE_FMT_S32 || m_dst_fmt == AV_SAMPLE_FMT_S32P)
++  {
++    av_opt_set_int(m_pContext, "output_sample_bits", m_dst_bits, 0);
++  }
++
++  // tell resampler to clamp float values
++  // not required for sink stage (remapLayout == true)
++  if ((m_dst_fmt == AV_SAMPLE_FMT_FLT || m_dst_fmt == AV_SAMPLE_FMT_FLTP) &&
++      (m_src_fmt == AV_SAMPLE_FMT_FLT || m_src_fmt == AV_SAMPLE_FMT_FLTP) && !remapLayout &&
++      normalize)
++  {
++    av_opt_set_double(m_pContext, "rematrix_maxval", 1.0, 0);
++  }
++
++  av_opt_set_double(m_pContext, "center_mix_level", centerMix, 0);
++
+   if(swr_init(m_pContext) < 0)
+   {
+     CLog::Log(LOGERROR, "CActiveAEResampleFFMPEG::Init - init resampler failed");
+diff --git a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+index 1aebc3dcbc..174df53f16 100644
+--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
++++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+@@ -376,74 +376,7 @@ bool CDVDDemuxFFmpeg::Open(const std::shared_ptr<CDVDInputStream>& pInput, bool
+     if (iformat == nullptr)
+     {
+       // let ffmpeg decide which demuxer we have to open
+-      bool trySPDIFonly = (m_pInput->GetContent() == "audio/x-spdif-compressed");
+-
+-      if (!trySPDIFonly)
+-        av_probe_input_buffer(m_ioContext, &iformat, strFile.c_str(), NULL, 0, 0);
+-
+-      // Use the more low-level code in case we have been built against an old
+-      // FFmpeg without the above av_probe_input_buffer(), or in case we only
+-      // want to probe for spdif (DTS or IEC 61937) compressed audio
+-      // specifically, or in case the file is a wav which may contain DTS or
+-      // IEC 61937 (e.g. ac3-in-wav) and we want to check for those formats.
+-      if (trySPDIFonly || (iformat && strcmp(iformat->name, "wav") == 0))
+-      {
+-        AVProbeData pd;
+-        int probeBufferSize = 32768;
+-        std::unique_ptr<uint8_t[]> probe_buffer (new uint8_t[probeBufferSize + AVPROBE_PADDING_SIZE]);
+-
+-        // init probe data
+-        pd.buf = probe_buffer.get();
+-        pd.filename = strFile.c_str();
+-
+-        // read data using avformat's buffers
+-        pd.buf_size = avio_read(m_ioContext, pd.buf, probeBufferSize);
+-        if (pd.buf_size <= 0)
+-        {
+-          CLog::Log(LOGERROR, "{} - error reading from input stream, {}", __FUNCTION__,
+-                    CURL::GetRedacted(strFile));
+-          return false;
+-        }
+-        memset(pd.buf + pd.buf_size, 0, AVPROBE_PADDING_SIZE);
+-
+-        // restore position again
+-        avio_seek(m_ioContext , 0, SEEK_SET);
+-
+-        // the advancedsetting is for allowing the user to force outputting the
+-        // 44.1 kHz DTS wav file as PCM, so that an A/V receiver can decode
+-        // it (this is temporary until we handle 44.1 kHz passthrough properly)
+-        if (trySPDIFonly || (iformat && strcmp(iformat->name, "wav") == 0 && !CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_VideoPlayerIgnoreDTSinWAV))
+-        {
+-          // check for spdif and dts
+-          // This is used with wav files and audio CDs that may contain
+-          // a DTS or AC3 track padded for S/PDIF playback. If neither of those
+-          // is present, we assume it is PCM audio.
+-          // AC3 is always wrapped in iec61937 (ffmpeg "spdif"), while DTS
+-          // may be just padded.
+-          const AVInputFormat* iformat2 = av_find_input_format("spdif");
+-          if (iformat2 && iformat2->read_probe(&pd) > AVPROBE_SCORE_MAX / 4)
+-          {
+-            iformat = iformat2;
+-          }
+-          else
+-          {
+-            // not spdif or no spdif demuxer, try dts
+-            iformat2 = av_find_input_format("dts");
+-
+-            if (iformat2 && iformat2->read_probe(&pd) > AVPROBE_SCORE_MAX / 4)
+-            {
+-              iformat = iformat2;
+-            }
+-            else if (trySPDIFonly)
+-            {
+-              // not dts either, return false in case we were explicitly
+-              // requested to only check for S/PDIF padded compressed audio
+-              CLog::Log(LOGDEBUG, "{} - not spdif or dts file, falling back", __FUNCTION__);
+-              return false;
+-            }
+-          }
+-        }
+-      }
++      av_probe_input_buffer(m_ioContext, &iformat, strFile.c_str(), NULL, 0, 0);
+ 
+       if (!iformat)
+       {
+@@ -1353,7 +1286,7 @@ bool CDVDDemuxFFmpeg::SeekTime(double time, bool backwards, double* startpts)
+ 
+     if (ret >= 0)
+     {
+-      if (m_pFormatContext->iformat->read_seek)
++      if (!(m_pFormatContext->iformat->flags & AVFMT_NOTIMESTAMPS))
+         m_seekToKeyFrame = true;
+       m_currentPts = DVD_NOPTS_VALUE;
+     }
+-- 
+2.43.0
+
+
+From 17ce23505f171235ac6bfff7fbaa3a5b4bc9a8bf Mon Sep 17 00:00:00 2001
+From: Stephan Sundermann <stephansundermann@gmail.com>
+Date: Thu, 11 Apr 2024 17:13:36 +0200
+Subject: [PATCH 2/7] [ffmpeg] Remove deprecated use of FF_API_INTERLACED_FRAME
+
+---
+ .../DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp            | 5 +++--
+ .../VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp  | 9 +++++----
+ xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp         | 6 ++++--
+ xbmc/cores/VideoPlayer/DVDCodecs/Video/VTB.cpp           | 2 +-
+ 4 files changed, 13 insertions(+), 9 deletions(-)
+
+diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+index eb2943bb8c..4da0722d5c 100644
+--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
++++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+@@ -582,8 +582,9 @@ void CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)
+ 
+   pVideoPicture->iRepeatPicture = 0;
+   pVideoPicture->iFlags = 0;
+-  pVideoPicture->iFlags |= m_pFrame->interlaced_frame ? DVP_FLAG_INTERLACED : 0;
+-  pVideoPicture->iFlags |= m_pFrame->top_field_first ? DVP_FLAG_TOP_FIELD_FIRST : 0;
++  pVideoPicture->iFlags |= m_pFrame->flags & AV_FRAME_FLAG_INTERLACED ? DVP_FLAG_INTERLACED : 0;
++  pVideoPicture->iFlags |=
++      m_pFrame->flags & AV_FRAME_FLAG_TOP_FIELD_FIRST ? DVP_FLAG_TOP_FIELD_FIRST : 0;
+   pVideoPicture->iFlags |= m_pFrame->data[0] ? 0 : DVP_FLAG_DROPPED;
+ 
+   if (m_codecControlFlags & DVD_CODEC_CTRL_DROP)
+diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+index d66378fa07..9586d211e9 100644
+--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
++++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+@@ -792,12 +792,12 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecFFmpeg::GetPicture(VideoPicture* pVideoPi
+   }
+   m_dropCtrl.Process(framePTS, m_pCodecContext->skip_frame > AVDISCARD_DEFAULT);
+ 
+-  if (m_pDecodedFrame->key_frame)
++  if (m_pDecodedFrame->flags & AV_FRAME_FLAG_KEY)
+   {
+     m_started = true;
+     m_iLastKeyframe = m_pCodecContext->has_b_frames + 2;
+   }
+-  if (m_pDecodedFrame->interlaced_frame)
++  if (m_pDecodedFrame->flags & AV_FRAME_FLAG_INTERLACED)
+     m_interlaced = true;
+   else
+     m_interlaced = false;
+@@ -1013,8 +1013,9 @@ bool CDVDVideoCodecFFmpeg::GetPictureCommon(VideoPicture* pVideoPicture)
+ 
+   pVideoPicture->iRepeatPicture = 0.5 * m_pFrame->repeat_pict;
+   pVideoPicture->iFlags = 0;
+-  pVideoPicture->iFlags |= m_pFrame->interlaced_frame ? DVP_FLAG_INTERLACED : 0;
+-  pVideoPicture->iFlags |= m_pFrame->top_field_first ? DVP_FLAG_TOP_FIELD_FIRST: 0;
++  pVideoPicture->iFlags |= m_pFrame->flags & AV_FRAME_FLAG_INTERLACED ? DVP_FLAG_INTERLACED : 0;
++  pVideoPicture->iFlags |=
++      m_pFrame->flags & AV_FRAME_FLAG_TOP_FIELD_FIRST ? DVP_FLAG_TOP_FIELD_FIRST : 0;
+ 
+   if (m_codecControlFlags & DVD_CODEC_CTRL_DROP)
+   {
+diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+index fb7606e0d0..a62fa6273d 100644
+--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
++++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+@@ -3068,8 +3068,10 @@ bool CFFmpegPostproc::AddPicture(CVaapiDecodedPicture &inPic)
+   m_pFilterFrameIn->height = m_config.vidHeight;
+   m_pFilterFrameIn->linesize[0] = image.pitches[0];
+   m_pFilterFrameIn->linesize[1] = image.pitches[1];
+-  m_pFilterFrameIn->interlaced_frame = (inPic.DVDPic.iFlags & DVP_FLAG_INTERLACED) ? 1 : 0;
+-  m_pFilterFrameIn->top_field_first = (inPic.DVDPic.iFlags & DVP_FLAG_TOP_FIELD_FIRST) ? 1 : 0;
++  if (inPic.DVDPic.iFlags & DVP_FLAG_INTERLACED)
++    m_pFilterFrameIn->flags |= AV_FRAME_FLAG_INTERLACED;
++  if (inPic.DVDPic.iFlags & DVP_FLAG_TOP_FIELD_FIRST)
++    m_pFilterFrameIn->flags |= AV_FRAME_FLAG_TOP_FIELD_FIRST;
+ 
+   if (inPic.DVDPic.pts == DVD_NOPTS_VALUE)
+     m_pFilterFrameIn->pts = AV_NOPTS_VALUE;
+diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VTB.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VTB.cpp
+index 1f71f643d2..567d63559d 100644
+--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VTB.cpp
++++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VTB.cpp
+@@ -196,7 +196,7 @@ CDVDVideoCodec::VCReturn CDecoder::Decode(AVCodecContext* avctx, AVFrame* frame)
+ 
+   if(frame)
+   {
+-    if (frame->interlaced_frame)
++    if (frame->flags & AV_FRAME_FLAG_INTERLACED)
+       return CDVDVideoCodec::VC_FATAL;
+ 
+     if (m_renderBuffer)
+-- 
+2.43.0
+
+
+From 01aa01d5c096ff7554c79493eab65dd41b00402f Mon Sep 17 00:00:00 2001
+From: Stephan Sundermann <stephansundermann@gmail.com>
+Date: Thu, 11 Apr 2024 17:14:48 +0200
+Subject: [PATCH 3/7] [ffmpeg] Remove deprecated use of avcodec_close
+
+---
+ xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+index 0cdf8c3864..477a2e82ec 100644
+--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
++++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+@@ -188,7 +188,6 @@ bool CDVDDemuxClient::ParsePacket(DemuxPacket* pkt)
+       if (!avcodec_open2(stream->m_context, stream->m_context->codec, nullptr))
+       {
+         avcodec_send_packet(stream->m_context, avpkt);
+-        avcodec_close(stream->m_context);
+       }
+     }
+     av_packet_free(&avpkt);
+-- 
+2.43.0
+
+
+From b509d439c18bebcf35cc80d18a0997caf6eda8a6 Mon Sep 17 00:00:00 2001
+From: Stephan Sundermann <stephansundermann@gmail.com>
+Date: Thu, 11 Apr 2024 17:15:16 +0200
+Subject: [PATCH 4/7] [ffmpeg] Remove deprecated use av_stream_get_side_data
+
+---
+ .../DVDDemuxers/DVDDemuxFFmpeg.cpp            | 53 +++++++++++--------
+ 1 file changed, 32 insertions(+), 21 deletions(-)
+
+diff --git a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+index 174df53f16..f917bf719f 100644
+--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
++++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+@@ -1630,42 +1630,49 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
+         st->colorRange = pStream->codecpar->color_range;
+         st->hdr_type = DetermineHdrType(pStream);
+ 
+-        // https://github.com/FFmpeg/FFmpeg/blob/release/5.0/doc/APIchanges
+-        size_t size = 0;
+-        uint8_t* side_data = nullptr;
++        // https://github.com/FFmpeg/FFmpeg/blob/release/7.0/doc/APIchanges
++        const AVPacketSideData* sideData = nullptr;
+ 
+         if (st->hdr_type == StreamHdrType::HDR_TYPE_DOLBYVISION)
+         {
+-          side_data = av_stream_get_side_data(pStream, AV_PKT_DATA_DOVI_CONF, &size);
+-          if (side_data && size)
++
++          sideData =
++              av_packet_side_data_get(pStream->codecpar->coded_side_data,
++                                      pStream->codecpar->nb_coded_side_data, AV_PKT_DATA_DOVI_CONF);
++          if (sideData && sideData->size)
+           {
+-            st->dovi = *reinterpret_cast<AVDOVIDecoderConfigurationRecord*>(side_data);
++            st->dovi = *reinterpret_cast<const AVDOVIDecoderConfigurationRecord*>(sideData->data);
+           }
+         }
+ 
+-        side_data = av_stream_get_side_data(pStream, AV_PKT_DATA_MASTERING_DISPLAY_METADATA, &size);
+-        if (side_data && size)
++        sideData = av_packet_side_data_get(pStream->codecpar->coded_side_data,
++                                           pStream->codecpar->nb_coded_side_data,
++                                           AV_PKT_DATA_MASTERING_DISPLAY_METADATA);
++        if (sideData && sideData->size)
+         {
+           st->masteringMetaData = std::make_shared<AVMasteringDisplayMetadata>(
+-              *reinterpret_cast<AVMasteringDisplayMetadata*>(side_data));
++              *reinterpret_cast<const AVMasteringDisplayMetadata*>(sideData->data));
+         }
+ 
+-        side_data = av_stream_get_side_data(pStream, AV_PKT_DATA_CONTENT_LIGHT_LEVEL, &size);
+-        if (side_data && size)
++        sideData = av_packet_side_data_get(pStream->codecpar->coded_side_data,
++                                           pStream->codecpar->nb_coded_side_data,
++                                           AV_PKT_DATA_CONTENT_LIGHT_LEVEL);
++        if (sideData && sideData->size)
+         {
+           st->contentLightMetaData = std::make_shared<AVContentLightMetadata>(
+-              *reinterpret_cast<AVContentLightMetadata*>(side_data));
++              *reinterpret_cast<const AVContentLightMetadata*>(sideData->data));
+         }
+ 
+-        uint8_t* displayMatrixSideData =
+-            av_stream_get_side_data(pStream, AV_PKT_DATA_DISPLAYMATRIX, nullptr);
+-        if (displayMatrixSideData)
++        sideData = av_packet_side_data_get(pStream->codecpar->coded_side_data,
++                                           pStream->codecpar->nb_coded_side_data,
++                                           AV_PKT_DATA_DISPLAYMATRIX);
++        if (sideData)
+         {
+-          const double tetha =
+-              av_display_rotation_get(reinterpret_cast<int32_t*>(displayMatrixSideData));
+-          if (!std::isnan(tetha))
++          const double theta =
++              av_display_rotation_get(reinterpret_cast<const int32_t*>(sideData->data));
++          if (!std::isnan(theta))
+           {
+-            st->iOrientation = ((static_cast<int>(-tetha) % 360) + 360) % 360;
++            st->iOrientation = ((static_cast<int>(-theta) % 360) + 360) % 360;
+           }
+         }
+ 
+@@ -2488,7 +2495,9 @@ StreamHdrType CDVDDemuxFFmpeg::DetermineHdrType(AVStream* pStream)
+ {
+   StreamHdrType hdrType = StreamHdrType::HDR_TYPE_NONE;
+ 
+-  if (av_stream_get_side_data(pStream, AV_PKT_DATA_DOVI_CONF, nullptr)) // DoVi
++  if (av_packet_side_data_get(pStream->codecpar->coded_side_data,
++                              pStream->codecpar->nb_coded_side_data,
++                              AV_PKT_DATA_DOVI_CONF)) // DoVi
+     hdrType = StreamHdrType::HDR_TYPE_DOLBYVISION;
+   else if (pStream->codecpar->color_trc == AVCOL_TRC_SMPTE2084) // HDR10
+     hdrType = StreamHdrType::HDR_TYPE_HDR10;
+@@ -2496,7 +2505,9 @@ StreamHdrType CDVDDemuxFFmpeg::DetermineHdrType(AVStream* pStream)
+     hdrType = StreamHdrType::HDR_TYPE_HLG;
+   // file could be SMPTE2086 which FFmpeg currently returns as unknown
+   // so use the presence of static metadata to detect it
+-  else if (av_stream_get_side_data(pStream, AV_PKT_DATA_MASTERING_DISPLAY_METADATA, nullptr))
++  else if (av_packet_side_data_get(pStream->codecpar->coded_side_data,
++                                   pStream->codecpar->nb_coded_side_data,
++                                   AV_PKT_DATA_MASTERING_DISPLAY_METADATA))
+     hdrType = StreamHdrType::HDR_TYPE_HDR10;
+ 
+   return hdrType;
+-- 
+2.43.0
+
+
+From 5e7609bfee5e0559d6c29b01fbc4294d27168921 Mon Sep 17 00:00:00 2001
+From: Stephan Sundermann <stephansundermann@gmail.com>
+Date: Thu, 11 Apr 2024 17:15:43 +0200
+Subject: [PATCH 5/7] [ffmpeg] Remove CrystalHD hw acceleration strings
+
+---
+ addons/resource.language.en_gb/resources/strings.po | 11 ++---------
+ 1 file changed, 2 insertions(+), 9 deletions(-)
+
+diff --git a/addons/resource.language.en_gb/resources/strings.po b/addons/resource.language.en_gb/resources/strings.po
+index 056b1747a0..292aae4a1b 100644
+--- a/addons/resource.language.en_gb/resources/strings.po
++++ b/addons/resource.language.en_gb/resources/strings.po
+@@ -7342,10 +7342,7 @@ msgctxt "#13427"
+ msgid "Allow hardware acceleration - DXVA2"
+ msgstr ""
+ 
+-#: system/settings/settings.xml
+-msgctxt "#13428"
+-msgid "Allow hardware acceleration - CrystalHD"
+-msgstr ""
++#empty string with id 13428
+ 
+ #: system/settings/settings.xml
+ msgctxt "#13429"
+@@ -19502,11 +19499,7 @@ msgctxt "#36158"
+ msgid "Enable DXVA2 hardware decoding of video files."
+ msgstr ""
+ 
+-#. Description of setting with label #13428 "Allow hardware acceleration (CrystalHD)"
+-#: system/settings/settings.xml
+-msgctxt "#36159"
+-msgid "Enable CrystalHD decoding of video files."
+-msgstr ""
++#empty string with id 36159
+ 
+ #. Description of setting with label #13429 "Allow hardware acceleration (VDADecoder)"
+ #: system/settings/settings.xml
+-- 
+2.43.0
+
+
+From 813a40bb30285b1b32a7ab6e63953eb3665f051a Mon Sep 17 00:00:00 2001
+From: Stephan Sundermann <stephansundermann@gmail.com>
+Date: Sat, 13 Apr 2024 10:31:36 +0200
+Subject: [PATCH 6/7] [settings] Remove VideoPlayerignoredtsinwav advanced
+ setting
+
+---
+ xbmc/settings/AdvancedSettings.cpp | 2 --
+ xbmc/settings/AdvancedSettings.h   | 1 -
+ 2 files changed, 3 deletions(-)
+
+diff --git a/xbmc/settings/AdvancedSettings.cpp b/xbmc/settings/AdvancedSettings.cpp
+index cc06244799..4e2d6badd6 100644
+--- a/xbmc/settings/AdvancedSettings.cpp
++++ b/xbmc/settings/AdvancedSettings.cpp
+@@ -129,7 +129,6 @@ void CAdvancedSettings::Initialize()
+     return;
+ 
+   m_audioApplyDrc = -1.0f;
+-  m_VideoPlayerIgnoreDTSinWAV = false;
+ 
+   //default hold time of 25 ms, this allows a 20 hertz sine to pass undistorted
+   m_limiterHold = 0.025f;
+@@ -579,7 +578,6 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
+       GetCustomRegexps(pAudioExcludes, m_audioExcludeFromScanRegExps);
+ 
+     XMLUtils::GetFloat(pElement, "applydrc", m_audioApplyDrc);
+-    XMLUtils::GetBoolean(pElement, "VideoPlayerignoredtsinwav", m_VideoPlayerIgnoreDTSinWAV);
+ 
+     XMLUtils::GetFloat(pElement, "limiterhold", m_limiterHold, 0.0f, 100.0f);
+     XMLUtils::GetFloat(pElement, "limiterrelease", m_limiterRelease, 0.001f, 100.0f);
+diff --git a/xbmc/settings/AdvancedSettings.h b/xbmc/settings/AdvancedSettings.h
+index 3351caff55..8eabfe8240 100644
+--- a/xbmc/settings/AdvancedSettings.h
++++ b/xbmc/settings/AdvancedSettings.h
+@@ -120,7 +120,6 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
+ 
+     std::string m_audioDefaultPlayer;
+     float m_audioPlayCountMinimumPercent;
+-    bool m_VideoPlayerIgnoreDTSinWAV;
+     float m_limiterHold;
+     float m_limiterRelease;
+ 
+-- 
+2.43.0
+
+
+From 03449b80c2e00a56912b9612afc11f3d53dd4a05 Mon Sep 17 00:00:00 2001
+From: Stephan Sundermann <stephansundermann@gmail.com>
+Date: Sat, 13 Apr 2024 13:07:58 +0200
+Subject: [PATCH 7/7] [ffmpeg] Use new audio DTS and ATMOS profiles
+
+---
+ .../VideoPlayer/DVDDemuxers/DVDDemux.cpp      | 20 +++++++++++++------
+ .../DVDInputStreams/InputStreamAddon.cpp      |  9 +++------
+ 2 files changed, 17 insertions(+), 12 deletions(-)
+
+diff --git a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.cpp b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.cpp
+index 63fb9264a8..e9aa468dd0 100644
+--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.cpp
++++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.cpp
+@@ -15,15 +15,15 @@ std::string CDemuxStreamAudio::GetStreamType()
+   std::string strInfo;
+   switch (codec)
+   {
+-    //! @todo: With ffmpeg >= 6.1 add new AC4 codec
+     case AV_CODEC_ID_AC3:
+       strInfo = "AC3 ";
+       break;
++    case AV_CODEC_ID_AC4:
++      strInfo = "AC4 ";
++      break;
+     case AV_CODEC_ID_EAC3:
+     {
+-      //! @todo: With ffmpeg >= 6.1 add new atmos profile case
+-      // "JOC" its EAC3 Atmos underlying profile, there is no standard codec name string
+-      if (StringUtils::Contains(codecName, "JOC"))
++      if (profile == FF_PROFILE_EAC3_DDP_ATMOS)
+         strInfo = "DD+ ATMOS ";
+       else
+         strInfo = "DD+ ";
+@@ -31,7 +31,6 @@ std::string CDemuxStreamAudio::GetStreamType()
+     }
+     case AV_CODEC_ID_DTS:
+     {
+-      //! @todo: With ffmpeg >= 6.1 add new DTSX profile cases
+       switch (profile)
+       {
+         case FF_PROFILE_DTS_96_24:
+@@ -49,6 +48,12 @@ std::string CDemuxStreamAudio::GetStreamType()
+         case FF_PROFILE_DTS_HD_HRA:
+           strInfo = "DTS-HD HRA ";
+           break;
++        case FF_PROFILE_DTS_HD_MA_X:
++          strInfo = "DTS-HD MA X ";
++          break;
++        case FF_PROFILE_DTS_HD_MA_X_IMAX:
++          strInfo = "DTS-HD MA X (IMAX) ";
++          break;
+         default:
+           strInfo = "DTS ";
+           break;
+@@ -62,7 +67,10 @@ std::string CDemuxStreamAudio::GetStreamType()
+       strInfo = "MP3 ";
+       break;
+     case AV_CODEC_ID_TRUEHD:
+-      strInfo = "TrueHD ";
++      if (profile == FF_PROFILE_TRUEHD_ATMOS)
++        strInfo = "TrueHD ATMOS ";
++      else
++        strInfo = "TrueHD ";
+       break;
+     case AV_CODEC_ID_AAC:
+     {
+diff --git a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+index daf66ce0cd..902f38ade2 100644
+--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
++++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+@@ -762,14 +762,11 @@ int CInputStreamAddon::ConvertAudioCodecProfile(STREAMCODEC_PROFILE profile)
+     case DTSCodecProfileHDExpress:
+       return FF_PROFILE_DTS_EXPRESS;
+     case DTSCodecProfileHDMAX:
+-      //! @todo: with ffmpeg >= 6.1 set the appropriate profile
+-      return FF_PROFILE_UNKNOWN; // FF_PROFILE_DTS_HD_MA_X
++      return FF_PROFILE_DTS_HD_MA_X;
+     case DTSCodecProfileHDMAIMAX:
+-      //! @todo: with ffmpeg >= 6.1 set the appropriate profile
+-      return FF_PROFILE_UNKNOWN; // FF_PROFILE_DTS_HD_MA_X_IMAX
++      return FF_PROFILE_DTS_HD_MA_X_IMAX;
+     case DDPlusCodecProfileAtmos:
+-      //! @todo: with ffmpeg >= 6.1 set the appropriate profile
+-      return FF_PROFILE_UNKNOWN; // FF_PROFILE_EAC3_DDP_ATMOS
++      return FF_PROFILE_EAC3_DDP_ATMOS;
+     default:
+       return FF_PROFILE_UNKNOWN;
+   }
+
+-- 
+2.43.0

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -82,12 +82,12 @@ modules:
       - /share/doc
     sources:
       - type: archive
-        url: https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n6.1.4.tar.gz
-        sha256: 78dd367fbfc5d4a9949d528808334accffcc8e898aee30fa9fab6999c4751e3a
+        url: https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n7.1.3.tar.gz
+        sha256: e0b04c4b43d7e6d67cb6710334fb513adf13ac860532f30e1d0ac4c231f232fb
         x-checker-data:
           type: anitya
           project-id: 5405
-          versions: {<: 7.0.0}
+          versions: {<: 8.0.0}
           url-template: https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n$version.tar.gz
   - name: flatbuffers
     buildsystem: cmake-ninja
@@ -815,6 +815,8 @@ modules:
         sha512: 51e6fc033121241354a5f0b3fc9a430577ae3ff6bb7f31445aa548ef4893037fb80eea3b2c6774c81e9ebaf9c45e9b490c98c2c65eb38f9f7daba84b236f7e1d
         dest: build/download/
         dest-filename: libdvdnav.tar.gz
+      - type: patch
+        path: patches/ffmpeg7.patch
 
   - name: kodi-platform
     buildsystem: cmake-ninja


### PR DESCRIPTION
Related to https://github.com/xbmc/xbmc/pull/24972, and inputstream addon patches from upstream/Debian.

This build works well with my PVR (NextPVR) and a selection of high bitrate video files. Could potentially address the issue discussed in https://github.com/flathub/tv.kodi.Kodi/issues/422 (but may come with its own). 