### PR TITLE
omega: revert to runtime 24.08 until EOL ~ Sept 2026

### DIFF
--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -1,6 +1,6 @@
 app-id: tv.kodi.Kodi
 runtime: org.freedesktop.Platform
-runtime-version: '25.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.openjdk17
@@ -737,6 +737,25 @@ modules:
               type: anitya
               project-id: 2610
               url-template: http://prdownloads.sourceforge.net/pcre/pcre-$version.tar.bz2
+  # taglib and lzo may be dropped once we move on from runtime 24.08
+  - name: taglib
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DBUILD_SHARED_LIBS=ON
+      - -DCMAKE_INSTALL_LIBDIR=lib
+    cleanup:
+      - /include
+      - /lib/*.so
+    sources:
+      - type: archive
+        url: https://taglib.org/releases/taglib-1.13.1.tar.gz
+        sha512: 986231ee62caa975afead7e94630d58acaac25a38bc33d4493d51bd635d79336e81bba60586d7355ebc0670e31f28d32da3ecceaf33292e4bc240c64bf00f35b
+        x-checker-data:
+          type: anitya
+          project-id: 1982
+          versions: {<: 2.0.0}
+          url-template: https://taglib.org/releases/taglib-$version.tar.gz
+  - shared-modules/lzo/lzo.json
   - name: kodi
     buildsystem: cmake-ninja
     config-opts:


### PR DESCRIPTION
taglib+lzo are required to step back to runtime 24.08

Runtime 25.08 dropped intel-vaapi-driver because intel abandoned it, and some of our users are looking for solutions because of that. We could potentially revert to 24.08 to allow some time (~4 months) for discussion, development, or users to think about what their long term solution might be.

It was relatively little effort to revert back to runtime 24.08 from 25.08 after the work put into https://github.com/flathub/tv.kodi.Kodi/commit/7cc7094e96cde5cfdfcdb03f47b5936ddc2c5e70, we retain all of the adjustments needed to switch back again easily.