### PR TITLE
master updates

### DIFF
--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -285,8 +285,8 @@ modules:
       - /lib/*.so
     sources:
       - type: archive
-        url: https://github.com/Pulse-Eight/libcec/archive/libcec-7.1.1.tar.gz
-        sha256: 7f7da95a4c1e7160d42ca37a3ac80cf6f389b317e14816949e0fa5e2edf4cc64
+        url: https://github.com/Pulse-Eight/libcec/archive/c7c4c82dc171c49decfbfe5d2959706d3e2ea47c.tar.gz
+        sha256: 1ea208bd6218d70102fead867c6c7ef92d5d9f6f78e5010bc0ce41312d24ccfd
         x-checker-data:
           type: anitya
           project-id: 21468


### PR DESCRIPTION
- [share-modules: update to githash 2dfad85 (fix json linter warnings)](https://github.com/flathub/tv.kodi.Kodi/commit/953f77697995403b6f712926998fdf5209f61158)
- [libcec: update to githash c7c4c82](https://github.com/flathub/tv.kodi.Kodi/commit/b54a751c1b9122120872689f862d33f22e8cf4b8)

The libcec update fixes a known regression discussed over in the LibreELEC forums (see commit for reference).