### PR TITLE
set LIBVA_DRIVERS_PATH excluding nvidia-vaapi-driver

### DIFF
--- a/patches/kodi.sh.in.set-LIBVA_DRIVERS_PATH-excluding-nvidia-vaapi-driver.patch
+++ b/patches/kodi.sh.in.set-LIBVA_DRIVERS_PATH-excluding-nvidia-vaapi-driver.patch
@@ -1,0 +1,15 @@
+--- a/tools/Linux/kodi.sh.in
++++ b/tools/Linux/kodi.sh.in
+@@ -32,6 +32,13 @@ export KODI_HOME=/app/share/kodi
+ # Workaround for high CPU load with nvidia GFX
+ export __GL_YIELD=USLEEP
+ 
++# set LIBVA_DRIVERS_PATH excluding nvidia-vaapi-driver
++case "$(uname -m)" in
++    x86_64)
++        export LIBVA_DRIVERS_PATH="/usr/lib/x86_64-linux-gnu/dri:/usr/lib/x86_64-linux-gnu/dri/intel-vaapi-driver:/usr/lib/x86_64-linux-gnu/GL/lib/dri"
++        ;;
++esac
++
+ # Fix wasting RAM due to fragmentation
+ export MALLOC_MMAP_THRESHOLD_=131072

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -780,6 +780,8 @@ modules:
           tag-pattern: ^([\d.]+)-\w+$
       - type: patch
         path: patches/kodi.sh.in.patch
+      - type: patch
+        path: patches/kodi.sh.in.set-LIBVA_DRIVERS_PATH-excluding-nvidia-vaapi-driver.patch
       - type: file
         path: addon-list.txt
         dest: build/download/


### PR DESCRIPTION
The freedesktop runtime builds libva with a compiled-in driver search path that includes the nvidia-vaapi-driver subdirectory. This causes libva to discover nvidia_drv_video.so regardless of whether LIBVA_DRIVERS_PATH is set in the environment. Kodi's VAAPI code path is not compatible with nvidia-vaapi-driver and the combination produces failures at runtime.

On x86_64, explicitly set LIBVA_DRIVERS_PATH to all compiled-in paths except the nvidia-vaapi-driver subdirectory, preventing libva from discovering nvidia_drv_video.so while preserving hardware acceleration for Intel and AMD users. On other architectures the nvidia-vaapi-driver is not present and libva's compiled-in defaults are left undisturbed.