### PR TITLE
master: fix several x-data-checker stanzas and update sources

### DIFF
--- a/addons/audiodecoder.openmpt/audiodecoder.openmpt.json
+++ b/addons/audiodecoder.openmpt/audiodecoder.openmpt.json
@@ -27,8 +27,13 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://lib.openmpt.org/files/libopenmpt/src/libopenmpt-0.8.6+release.autotools.tar.gz",
-                    "sha256": "caa2fa959e389f4374d9e2df3af5c633452c12dd80442cba2e89cb7ff2b93c5b"
+                    "url": "https://lib.openmpt.org/files/libopenmpt/src/libopenmpt-0.8.7+release.autotools.tar.gz",
+                    "sha256": "275c29ef47be9992f62a35fcc96f7ca05c06d2fd05c9298b8dee9f743f75b089",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 141468,
+                        "url-template": "https://lib.openmpt.org/files/libopenmpt/src/libopenmpt-$version+release.autotools.tar.gz"
+                    }
                 }
             ]
         }

--- a/addons/imagedecoder.heif/imagedecoder.heif.json
+++ b/addons/imagedecoder.heif/imagedecoder.heif.json
@@ -50,8 +50,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/strukturag/libheif/archive/v1.22.2/libheif-1.22.2.tar.gz",
-                    "sha256": "af30a8b32dfbc1dc86a7f0f55a53107dad35010a65ebf1feb468082e402b11e0",
+                    "url": "https://github.com/strukturag/libheif/archive/v1.23.0/libheif-1.23.0.tar.gz",
+                    "sha256": "50ea4fbd1e19c7b8820271d6d0c73f2623fec5d659ce9fae57e48dbeb94fab9a",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/strukturag/libheif/releases/latest",

--- a/addons/imagedecoder.heif/imagedecoder.heif.json
+++ b/addons/imagedecoder.heif/imagedecoder.heif.json
@@ -20,8 +20,16 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/strukturag/libde265/releases/download/v1.0.18/libde265-1.0.18.tar.gz",
-                    "sha256": "800478f3bf35f0621b14928ceb317579f3e8b23de4bd2aac29b6cb8be962bbd8"
+                    "url": "https://github.com/strukturag/libde265/archive/v1.1.0/libde265-1.1.0.tar.gz",
+                    "sha256": "46c1ddb660a7cceaf05e954180360d265dcb4ce7b5b682a7ab541cd8f55bb93e",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/strukturag/libde265/releases/latest",
+                        "tag-query": ".tag_name",
+                        "timestamp-query": ".published_at",
+                        "version-query": "$tag | sub(\"^[vV]\"; \"\")",
+                        "url-query": "\"https://github.com/strukturag/libde265/archive/\\($tag)/libde265-\\($version).tar.gz\""
+                    }
                 }
             ]
         },
@@ -42,8 +50,16 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/strukturag/libheif/releases/download/v1.21.2/libheif-1.21.2.tar.gz",
-                    "sha256": "75f530b7154bc93e7ecf846edfc0416bf5f490612de8c45983c36385aa742b42"
+                    "url": "https://github.com/strukturag/libheif/archive/v1.22.2/libheif-1.22.2.tar.gz",
+                    "sha256": "af30a8b32dfbc1dc86a7f0f55a53107dad35010a65ebf1feb468082e402b11e0",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/strukturag/libheif/releases/latest",
+                        "tag-query": ".tag_name",
+                        "timestamp-query": ".published_at",
+                        "version-query": "$tag | sub(\"^[vV]\"; \"\")",
+                        "url-query": "\"https://github.com/strukturag/libheif/archive/\\($tag)/libheif-\\($version).tar.gz\""
+                    }
                 }
             ]
         }

--- a/addons/imagedecoder.raw/imagedecoder.raw.json
+++ b/addons/imagedecoder.raw/imagedecoder.raw.json
@@ -19,8 +19,13 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/LibRaw/LibRaw/archive/refs/tags/0.22.1.tar.gz",
-                    "sha256": "e676248284075605aa2697a66eeed7dc258820bd1d4988c724d29edffd726726"
+                    "url": "https://www.libraw.org/data/LibRaw-0.22.1.tar.gz",
+                    "sha256": "a789dc4e2409e2901d93793a4e0b80c7b49d0d97cf6ad71c850eb7616acfd786",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 1709,
+                        "url-template": "https://www.libraw.org/data/LibRaw-$version.tar.gz"
+                    }
                 },
                 {
                     "type": "script",

--- a/addons/inputstream.rtmp/inputstream.rtmp.json
+++ b/addons/inputstream.rtmp/inputstream.rtmp.json
@@ -26,8 +26,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://mirrors.xbmc.org/build-deps/sources/rtmpdump-fa8646daeb19dfd12c181f7d19de708d623704c0.tar.gz",
-                    "sha256": "dba4d4d2e1c7de6884b01d98194b83cab6784669089fa3c919152087a3a38fd2"
+                    "url": "https://github.com/mirror/rtmpdump/archive/6f6bb1353fc84f4cc37138baa99f586750028a01.tar.gz",
+                    "sha256": "5d68d69710be21e86e766753d2bd25cb2ad1c853b0bc80ebe6b49a6cc507bfc0"
                 }
             ]
         }

--- a/addons/pvr.hdhomerun/pvr.hdhomerun.json
+++ b/addons/pvr.hdhomerun/pvr.hdhomerun.json
@@ -23,8 +23,16 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/Silicondust/libhdhomerun/archive/7c54382fb681d03888b469033e50bebaf4ce6bce.tar.gz",
-                    "sha256": "d686f88b8dc6089e2cb3829958170d6ba02ecc4f2c5f2cfe3fd37e0dda76ce42"
+                    "url": "https://github.com/Silicondust/libhdhomerun/archive/20260313/libhdhomerun-20260313.tar.gz",
+                    "sha256": "92a1df224a7c3636b596fc0ca44c9debe0b92440f5287686af79a756b8f5200a",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/Silicondust/libhdhomerun/releases/latest",
+                        "tag-query": ".tag_name",
+                        "timestamp-query": ".published_at",
+                        "version-query": "$tag",
+                        "url-query": "\"https://github.com/Silicondust/libhdhomerun/archive/\\($tag)/libhdhomerun-\\($version).tar.gz\""
+                    }
                 },
                 {
                     "type": "file",

--- a/addons/vfs.sftp/vfs.sftp.json
+++ b/addons/vfs.sftp/vfs.sftp.json
@@ -25,10 +25,14 @@
             },
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://git.libssh.org/projects/libssh.git/",
-                    "tag": "libssh-0.12.0",
-                    "commit": "50313883f3a077458cde4ea95bf46bfeb0771b34"
+                    "type": "archive",
+                    "url": "https://git.libssh.org/projects/libssh.git/snapshot/libssh-0.12.0.tar.gz",
+                    "sha256": "a93c97f539f23a213734fa4a1807c7da577ad155d78145d44fd2af26bfb0e2ea",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 1729,
+                        "url-template": "https://git.libssh.org/projects/libssh.git/snapshot/libssh-$version.tar.gz"
+                    }
                 }
             ]
         }

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -162,8 +162,8 @@ modules:
       - --datarootdir=${FLATPAK_DEST}/lib/
     sources:
       - type: archive
-        url: https://github.com/vcrhonek/hwdata/archive/v0.406/hwdata-0.406.tar.gz
-        sha256: 1ccfd1ca723595b1fe8794f4157ec5635be1ebedb5d13769b4be75d0b75bc199
+        url: https://github.com/vcrhonek/hwdata/archive/v0.407/hwdata-0.407.tar.gz
+        sha256: 6a88f6f5cb510fbfaa9c49488348b7fcd7aa209b0a331f24dfebb1c8c339568b
         x-checker-data:
           type: anitya
           project-id: 5387

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -162,13 +162,13 @@ modules:
       - --datarootdir=${FLATPAK_DEST}/lib/
     sources:
       - type: archive
-        url: https://github.com/vcrhonek/hwdata/archive/refs/tags/v0.406.tar.gz
+        url: https://github.com/vcrhonek/hwdata/archive/v0.406/hwdata-0.406.tar.gz
         sha256: 1ccfd1ca723595b1fe8794f4157ec5635be1ebedb5d13769b4be75d0b75bc199
         x-checker-data:
           type: anitya
-          project-id: 13577
+          project-id: 5387
           stable-only: true
-          url-template: https://github.com/vcrhonek/hwdata/archive/refs/tags/v$version.tar.gz
+          url-template: https://github.com/vcrhonek/hwdata/archive/v$version/hwdata-$version.tar.gz
     cleanup:
       - /lib/pkgconfig
   - name: json
@@ -253,7 +253,7 @@ modules:
         x-checker-data:
           type: anitya
           project-id: 1565
-          url-template: https://download.videolan.org/pub/videolan/libbluray/$version/libbluray-$version.tar.bz2
+          url-template: https://download.videolan.org/pub/videolan/libbluray/$version/libbluray-$version.tar.xz
   - name: libcdio
     config-opts:
       - --enable-cxx
@@ -410,12 +410,12 @@ modules:
       - /lib/*.so
     sources:
       - type: archive
-        url: http://mirrors.kodi.tv/build-deps/sources/libudfread-1.2.0.tar.bz2
+        url: https://code.videolan.org/videolan/libudfread/-/archive/1.2.0/libudfread-1.2.0.tar.bz2
         sha512: 53df39c207cadd742b4d4f78fd14159a6e4f45c97c9a7b97a39778fab4fdb5b0c087ebba04d27c28b8078681b82c3e903a4394f0d381cdadf23d2fd24956261f
         x-checker-data:
           type: anitya
           project-id: 89591
-          url-template: http://mirrors.kodi.tv/build-deps/sources/libudfread-$version.tar.gz
+          url-template: https://code.videolan.org/videolan/libudfread/-/archive/$version/libudfread-$version.tar.bz2
   - name: mariadb-connector
     buildsystem: cmake-ninja
     config-opts:


### PR DESCRIPTION
This PR fixes several several x-data-checker stanzas and updates:
- libopenmpt to 0.8.7
- libde265 to 1.1.0
- libheif to 1.23.0
- rtmpdump to latest githash
- libhdhomerun to 20260313
- hwdata to 0.407
- rtmpdump: use github mirror and update to latest