### PR TITLE
master-updates

### DIFF
--- a/addons/imagedecoder.heif/imagedecoder.heif.json
+++ b/addons/imagedecoder.heif/imagedecoder.heif.json
@@ -50,8 +50,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/strukturag/libheif/archive/v1.23.0/libheif-1.23.0.tar.gz",
-                    "sha256": "50ea4fbd1e19c7b8820271d6d0c73f2623fec5d659ce9fae57e48dbeb94fab9a",
+                    "url": "https://github.com/strukturag/libheif/archive/v1.23.1/libheif-1.23.1.tar.gz",
+                    "sha256": "0b14d6bdf5680488e3aede354b1e11be1444b3fc4a30fcf2ae06bd6b601466be",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/strukturag/libheif/releases/latest",

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -592,8 +592,8 @@ modules:
           - --enable-compat-libdns_sd
         sources:
           - type: archive
-            url: https://github.com/avahi/avahi/archive/refs/tags/v0.9-rc4.tar.gz
-            sha256: 08fcc57377ed05416ec4b3d8a179da716a7a9376821551a5ae16f8276a1ef0b5
+            url: https://github.com/avahi/avahi/archive/refs/tags/v0.9-rc5.tar.gz
+            sha256: 5b0a9d88110b0fc8aaafc5cc0a26e83e7d2a4aca3a36bc27c9b626db7ead27b0
             x-checker-data:
               type: anitya
               project-id: 147


### PR DESCRIPTION
- update avahi to 0.9-rc5 (Closes: #737)
- update libheif to 1.23.1 (Closes: #738)