### PR TITLE
master - fedc: update upstream sources

### DIFF
--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -162,8 +162,8 @@ modules:
       - --datarootdir=${FLATPAK_DEST}/lib/
     sources:
       - type: archive
-        url: https://github.com/vcrhonek/hwdata/archive/v0.409/hwdata-0.409.tar.gz
-        sha256: 23006accc0f931dd5187d0307a57d0744e2b8feb85e73c37bc0f5229fb31eadd
+        url: https://github.com/vcrhonek/hwdata/archive/v0.410/hwdata-0.410.tar.gz
+        sha256: 2864b061b179b8ad8cb6a7339ca07678240a183d9cedce8677a4950acaf798e0
         x-checker-data:
           type: anitya
           project-id: 5387
@@ -205,8 +205,8 @@ modules:
       - --disable-static
     sources:
       - type: archive
-        url: https://download.videolan.org/videolan/libaacs/0.11.1/libaacs-0.11.1.tar.bz2
-        sha256: a88aa0ebe4c98a77f7aeffd92ab3ef64ac548c6b822e8248a8b926725bea0a39
+        url: https://download.videolan.org/videolan/libaacs/0.12.0/libaacs-0.12.0.tar.bz2
+        sha256: 1996673a9fc45ee4a364c66ffa84756629bf3923e52346c7358b71becb8e4419
         x-checker-data:
           type: anitya
           project-id: 5562
@@ -214,7 +214,6 @@ modules:
       - type: script
         dest-filename: autogen.sh
         commands:
-          - rm -fv m4/libgcrypt.m4
           - autoreconf -vfi
   - name: libbdplus
     rm-configure: true
@@ -245,11 +244,10 @@ modules:
       - -Denable_devtools=false
       - -Denable_examples=false
       - -Dbdj_jar=disabled
-      - -Djava9=false
     sources:
       - type: archive
-        url: https://download.videolan.org/pub/videolan/libbluray/1.4.0/libbluray-1.4.0.tar.xz
-        sha512: 7284169b32624e5ca4fd71b260a4cc2921efafb1f63143a562568be45e373bfcbfeac63895d5659ccdcb11d7dbd0236cc46ccb15c12eff855703010e46991f27
+        url: https://download.videolan.org/pub/videolan/libbluray/1.5.0/libbluray-1.5.0.tar.xz
+        sha512: f35d89097ad0c263ffa2102aba0068e7fe9b85afe27b14cf3c34ed6eff5876d1528aa8a62c3941b767353be2e1de4ae765f1402bd44af4544d922ffb69cea354
         x-checker-data:
           type: anitya
           project-id: 1565
@@ -362,8 +360,8 @@ modules:
       - /lib/*.so
     sources:
       - type: archive
-        url: https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-1.0.7.tar.gz
-        sha256: 827250db649546cdb04bea01f5f0560f0edffde9130e256387d1f977242eaf98
+        url: https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-1.0.9.tar.gz
+        sha256: 6e9adc446b08083ec03d40317fb66ca6f2e03e4f6170aef33a6e59bb08db2012
         x-checker-data:
           type: anitya
           project-id: 1658


### PR DESCRIPTION
- hwdata 0.410
- libaacs 0.12.0
- libbluray 1.5.0
- libmicrohttpd 1.0.9

libaacs 0.12.0 looks for libgcrypt with pkg-config, so its bundled m4/libgcrypt.m4 no longer has to be deleted before autoreconf runs. libbluray 1.5.0 no longer has a java9 meson option.

Closes: https://github.com/flathub/tv.kodi.Kodi/pull/764
Closes: https://github.com/flathub/tv.kodi.Kodi/pull/765
Closes: https://github.com/flathub/tv.kodi.Kodi/pull/767