### PR TITLE
beta updates

### DIFF
--- a/addons/audiodecoder.fluidsynth/audiodecoder.fluidsynth.json
+++ b/addons/audiodecoder.fluidsynth/audiodecoder.fluidsynth.json
@@ -45,8 +45,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/FluidSynth/fluidsynth/archive/refs/tags/v2.5.7.tar.gz",
-                    "sha256": "ce27840221ab00dd59bf27e85ecbba480c6c2a7c9fbec4243658f68f59c07f4a",
+                    "url": "https://github.com/FluidSynth/fluidsynth/archive/refs/tags/v2.6.0.tar.gz",
+                    "sha256": "6d17570ea2086dd6fbcac995465773a6f316e689089b7fb7ba0b34c2ec6f680d",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 10437,

--- a/addons/game.libretro.81/game.libretro.81.json
+++ b/addons/game.libretro.81/game.libretro.81.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.81",
-            "commit": "511d2d355d831d53475eb47e6718f024943329dc"
+            "commit": "95a604ab38f833a7aa1830c6319a539ca71079e2"
         }
     ],
     "modules": [

--- a/addons/game.libretro.a5200/game.libretro.a5200.json
+++ b/addons/game.libretro.a5200/game.libretro.a5200.json
@@ -36,7 +36,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/libretro/a5200",
-                    "commit": "23c1ea482afb08656ec507e9ce98ed242a20bdfa"
+                    "commit": "40c6f2f1ad4a3145b328d5baaf010fae6c7e752b"
                 }
             ]
         }

--- a/addons/game.libretro.a5200/game.libretro.a5200.json
+++ b/addons/game.libretro.a5200/game.libretro.a5200.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.a5200",
-            "commit": "f9fd589e5b64b75a0470cee02c8b72a92a081b11"
+            "commit": "1ee9d0e387ff15513e406c90f05f7e9ef45ca2d8"
         }
     ],
     "modules": [

--- a/addons/game.libretro.atari800/game.libretro.atari800.json
+++ b/addons/game.libretro.atari800/game.libretro.atari800.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.atari800",
-            "commit": "deec5c2cf4338902466b595e0b0a0d146d4cb9f8"
+            "commit": "779cd8428b670b8efb352ebf1e07c87be626887f"
         }
     ],
     "modules": [

--- a/addons/game.libretro.beetle-bsnes/game.libretro.beetle-bsnes.json
+++ b/addons/game.libretro.beetle-bsnes/game.libretro.beetle-bsnes.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.beetle-bsnes",
-            "commit": "cc388ddc8f52119021b975d486d8c5f960029c8a"
+            "commit": "016f1107b98fb946040258504106f0019a977a4c"
         }
     ],
     "modules": [

--- a/addons/game.libretro.beetle-ngp/game.libretro.beetle-ngp.json
+++ b/addons/game.libretro.beetle-ngp/game.libretro.beetle-ngp.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.beetle-ngp",
-            "commit": "9cd33bb2049a8f0e013f5f94dae82dc4a4783e3e"
+            "commit": "11c5767cfde9fef647fba1f0f81808ba0bdab19f"
         }
     ],
     "modules": [

--- a/addons/game.libretro.beetle-psx/game.libretro.beetle-psx.json
+++ b/addons/game.libretro.beetle-psx/game.libretro.beetle-psx.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.beetle-psx",
-            "commit": "e5d7103ecbde68d427eb1398b2f802cd08b12f4b"
+            "commit": "b70c2c70a5bef4c23576a4469fa14fc2927a32c0"
         }
     ],
     "modules": [

--- a/addons/game.libretro.beetle-psx/game.libretro.beetle-psx.json
+++ b/addons/game.libretro.beetle-psx/game.libretro.beetle-psx.json
@@ -36,7 +36,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/libretro/beetle-psx-libretro",
-                    "commit": "d45d9d1a8c3f59b7345e19d4ea66b187cb1fbe7b"
+                    "commit": "ed640fac8986d7813e4db6604544a6aafddd3018"
                 }
             ]
         }

--- a/addons/game.libretro.beetle-saturn/game.libretro.beetle-saturn.json
+++ b/addons/game.libretro.beetle-saturn/game.libretro.beetle-saturn.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.beetle-saturn",
-            "commit": "2abde6bede9d1d5d6edecef4f78a0f172a6ccac4"
+            "commit": "615d3f8bf90ad06d684a5cae2c6f39b72c4e1429"
         }
     ],
     "modules": [

--- a/addons/game.libretro.beetle-saturn/game.libretro.beetle-saturn.json
+++ b/addons/game.libretro.beetle-saturn/game.libretro.beetle-saturn.json
@@ -36,7 +36,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/libretro/beetle-saturn-libretro",
-                    "commit": "262c4ff521e96e3807a94fde041f332324be5cff"
+                    "commit": "84461434f249c1b5cd10c83ae922feae84e1acf8"
                 }
             ]
         }

--- a/addons/game.libretro.beetle-vb/game.libretro.beetle-vb.json
+++ b/addons/game.libretro.beetle-vb/game.libretro.beetle-vb.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.beetle-vb",
-            "commit": "1f432508d31b7b763b7cf0cbbdf9a0e5c4d8c5a2"
+            "commit": "3227a8e1d085c4aefa6db8aee516d76cf1813626"
         }
     ],
     "modules": [

--- a/addons/game.libretro.beetle-vb/game.libretro.beetle-vb.json
+++ b/addons/game.libretro.beetle-vb/game.libretro.beetle-vb.json
@@ -36,7 +36,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/libretro/beetle-vb-libretro",
-                    "commit": "7cc663e9044459b3dab1790bdce8f48dc7358ed6"
+                    "commit": "3f53a40bf8aa18777514fd4b220960427e312a3f"
                 }
             ]
         }

--- a/addons/game.libretro.beetle-wswan/game.libretro.beetle-wswan.json
+++ b/addons/game.libretro.beetle-wswan/game.libretro.beetle-wswan.json
@@ -36,7 +36,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/libretro/beetle-wswan-libretro",
-                    "commit": "da6d0d9acb8d4e9bd6725ab44225a275325d8352"
+                    "commit": "4b01295838ea89e3f1355bbe4cb5cf98aa6108cd"
                 }
             ]
         }

--- a/addons/game.libretro.beetle-wswan/game.libretro.beetle-wswan.json
+++ b/addons/game.libretro.beetle-wswan/game.libretro.beetle-wswan.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.beetle-wswan",
-            "commit": "82b22c4848f346ac0e6f6a8cebde7c0ad961aa0f"
+            "commit": "6367f92c623fcb8a0257f1b9e3946eb76fab5ab3"
         }
     ],
     "modules": [

--- a/addons/game.libretro.bk/game.libretro.bk.json
+++ b/addons/game.libretro.bk/game.libretro.bk.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.bk",
-            "commit": "e8af6a4a4c3f40ab4c96ac06f102651d6e4565a6"
+            "commit": "b94fbc3a21f0db86b0c8288cd2ab797081b99229"
         }
     ],
     "modules": [

--- a/addons/game.libretro.blastem/game.libretro.blastem.json
+++ b/addons/game.libretro.blastem/game.libretro.blastem.json
@@ -16,7 +16,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.blastem",
-            "commit": "6c616b609e78e802c3349356f81623b912b44da8"
+            "commit": "8795ed12c76543e8e187500b71078d543bc8d4bf"
         }
     ],
     "modules": [

--- a/addons/game.libretro.bluemsx/game.libretro.bluemsx.json
+++ b/addons/game.libretro.bluemsx/game.libretro.bluemsx.json
@@ -36,7 +36,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/libretro/blueMSX-libretro",
-                    "commit": "f1715c8bf6443c4de7cad254ea14037704f8058e"
+                    "commit": "0f32f52c48d3e772bfdf0379756f81f00b4e08bc"
                 }
             ]
         }

--- a/addons/game.libretro.bluemsx/game.libretro.bluemsx.json
+++ b/addons/game.libretro.bluemsx/game.libretro.bluemsx.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.bluemsx",
-            "commit": "9ea6cc7745da30b4b37711c4e72b92a4e2fe08ec"
+            "commit": "fbd03d077e905a2cab4cb954a9460956f86691e9"
         }
     ],
     "modules": [

--- a/addons/game.libretro.cap32/game.libretro.cap32.json
+++ b/addons/game.libretro.cap32/game.libretro.cap32.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.cap32",
-            "commit": "189b89e26213dd33ca09ce9795f08bcc8c1cc361"
+            "commit": "f6a68a4d19effe78397e40735df02bf5307955c0"
         }
     ],
     "modules": [

--- a/addons/game.libretro.dosbox-pure/game.libretro.dosbox-pure.json
+++ b/addons/game.libretro.dosbox-pure/game.libretro.dosbox-pure.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.dosbox-pure",
-            "commit": "42e79a77651cdf852b14752cbf1fd3890bd36985"
+            "commit": "c3a5859d3c194e7f2dad94d4b119b47179304ea7"
         }
     ],
     "modules": [

--- a/addons/game.libretro.fceumm/game.libretro.fceumm.json
+++ b/addons/game.libretro.fceumm/game.libretro.fceumm.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.fceumm",
-            "commit": "2b2270df973d7221052fd07c5bffc3b539787e42"
+            "commit": "a7d3e68bc248494bc410765705be11dc69c5af05"
         }
     ],
     "modules": [

--- a/addons/game.libretro.fuse/game.libretro.fuse.json
+++ b/addons/game.libretro.fuse/game.libretro.fuse.json
@@ -36,7 +36,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/libretro/fuse-libretro",
-                    "commit": "bce196fb774835fe65b3e5b821887a4ccf657167"
+                    "commit": "000a8ae51a5141d75c109a22150e37ba06d57910"
                 }
             ]
         }

--- a/addons/game.libretro.fuse/game.libretro.fuse.json
+++ b/addons/game.libretro.fuse/game.libretro.fuse.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.fuse",
-            "commit": "30fcce8e29b6caf05857eacfee86d25ce85d0755"
+            "commit": "d653ad6df9711c13ed7cfb3c1e9152871bce8e93"
         }
     ],
     "modules": [

--- a/addons/game.libretro.gambatte/game.libretro.gambatte.json
+++ b/addons/game.libretro.gambatte/game.libretro.gambatte.json
@@ -36,7 +36,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/libretro/gambatte-libretro",
-                    "commit": "9b3b5e3cc18ec92f460d37dd551eaf90c55bfcea"
+                    "commit": "96174369b3c30d9fc57c926fa3379c273dc6a9a5"
                 }
             ]
         }

--- a/addons/game.libretro.gambatte/game.libretro.gambatte.json
+++ b/addons/game.libretro.gambatte/game.libretro.gambatte.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.gambatte",
-            "commit": "ee8e0e9229e1a2330464886cdbadbd2d54b3aa54"
+            "commit": "f3ea032a761cee32c11792429c10945c6b6027a2"
         }
     ],
     "modules": [

--- a/addons/game.libretro.mupen64plus-nx/game.libretro.mupen64plus-nx.json
+++ b/addons/game.libretro.mupen64plus-nx/game.libretro.mupen64plus-nx.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.mupen64plus-nx",
-            "commit": "2cb3a4e5d3f991fc6d39f322381bb6e89611e49c"
+            "commit": "d2ac1da76bbf4826d48167fdea57c9aa8eb6cda5"
         }
     ],
     "modules": [

--- a/addons/game.libretro.nestopia/game.libretro.nestopia.json
+++ b/addons/game.libretro.nestopia/game.libretro.nestopia.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.nestopia",
-            "commit": "3dfe0665b47edb2a28891ae7321b35e29b94fc72"
+            "commit": "8cc726d6c4d0732290267eb8331befd1d5d963c5"
         }
     ],
     "modules": [

--- a/addons/game.libretro.nestopia/game.libretro.nestopia.json
+++ b/addons/game.libretro.nestopia/game.libretro.nestopia.json
@@ -36,7 +36,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/libretro/nestopia-libretro",
-                    "commit": "b0fd87dd07e3c52903435d302b04e5e97796f127"
+                    "commit": "d0f461cee801c509748606e91c8ff0563ef62cd6"
                 }
             ]
         }

--- a/addons/game.libretro.pcsx-rearmed/game.libretro.pcsx-rearmed.json
+++ b/addons/game.libretro.pcsx-rearmed/game.libretro.pcsx-rearmed.json
@@ -48,7 +48,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/libretro/pcsx_rearmed",
-                    "commit": "94f15b3a6b707070aeb0c58cab9bc4eddc1706ff"
+                    "commit": "da2cb8ecd17fd0932ab6d94774c0522beebce6e3"
                 }
             ]
         }

--- a/addons/game.libretro.pcsx-rearmed/game.libretro.pcsx-rearmed.json
+++ b/addons/game.libretro.pcsx-rearmed/game.libretro.pcsx-rearmed.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.pcsx-rearmed",
-            "commit": "850e3db7994b967faf4869d07a03db9fae991d5a"
+            "commit": "858d7edaa16c8d3c150663a667eabaa40a25688b"
         }
     ],
     "modules": [

--- a/addons/game.libretro.pokemini/game.libretro.pokemini.json
+++ b/addons/game.libretro.pokemini/game.libretro.pokemini.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.pokemini",
-            "commit": "4b14434c1b5f9063a54365e2da6addb774520903"
+            "commit": "46136a63dd2b9a6268c518ae840c2efd7a3ff5cb"
         }
     ],
     "modules": [

--- a/addons/game.libretro.pokemini/game.libretro.pokemini.json
+++ b/addons/game.libretro.pokemini/game.libretro.pokemini.json
@@ -36,7 +36,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/libretro/pokemini",
-                    "commit": "bb009b1379ad15f1514f20ca7cbf710b4af42b3e"
+                    "commit": "132111b76343559860532a1ccc094f93f1ed5650"
                 }
             ]
         }

--- a/addons/game.libretro.prboom/game.libretro.prboom.json
+++ b/addons/game.libretro.prboom/game.libretro.prboom.json
@@ -37,7 +37,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/libretro/libretro-prboom",
-                    "commit": "ac35b61d25317c869ba2f7f39ea4a9de1cc981aa"
+                    "commit": "b4046cef3641d6bb28c0394915bfcc732cc49652"
                 }
             ]
         }

--- a/addons/game.libretro.prboom/game.libretro.prboom.json
+++ b/addons/game.libretro.prboom/game.libretro.prboom.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.prboom",
-            "commit": "28215b711b56f80f750ada56a2ebbba30b47b624"
+            "commit": "ba4eb62598cabd01f16ac9ea34c5d6811e49bed0"
         }
     ],
     "modules": [

--- a/addons/game.libretro.prosystem/game.libretro.prosystem.json
+++ b/addons/game.libretro.prosystem/game.libretro.prosystem.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.prosystem",
-            "commit": "bc00799cd60060568cc28373a171e0b125f4c782"
+            "commit": "563d761aeb667ad5f9334708e1afbb76528e6278"
         }
     ],
     "modules": [

--- a/addons/game.libretro.quicknes/game.libretro.quicknes.json
+++ b/addons/game.libretro.quicknes/game.libretro.quicknes.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.quicknes",
-            "commit": "68cb2d0e1552bac3878fb9434bcfe4fd656c8249"
+            "commit": "0f8b76e068c54f21a912c903dbd683100ecad9d5"
         }
     ],
     "modules": [

--- a/addons/game.libretro.sameboy/game.libretro.sameboy.json
+++ b/addons/game.libretro.sameboy/game.libretro.sameboy.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.sameboy",
-            "commit": "a39c606b53b7458f8f0b58cfffb85aa79e0dac1b"
+            "commit": "5c7927fa286ecc4d91cfef98131dfb0a296eb857"
         }
     ],
     "modules": [

--- a/addons/game.libretro.stella/game.libretro.stella.json
+++ b/addons/game.libretro.stella/game.libretro.stella.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.stella",
-            "commit": "b29a9894e286e6630de43e24bd160413ebce86cf"
+            "commit": "9647e08bf540d019a177ef169a8ef9fd504ec60a"
         }
     ],
     "modules": [

--- a/addons/game.libretro.stella/game.libretro.stella.json
+++ b/addons/game.libretro.stella/game.libretro.stella.json
@@ -36,7 +36,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/stella-emu/stella",
-                    "commit": "90d01ecb309b9c3317ca762078d4df40681e111b"
+                    "commit": "3f819a0d5760c3113610d1d07deb4ce9ea187517"
                 }
             ]
         }

--- a/addons/game.libretro.supafaust/game.libretro.supafaust.json
+++ b/addons/game.libretro.supafaust/game.libretro.supafaust.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.supafaust",
-            "commit": "7d776812e0d794db97deb9d3b43c5880fb570c52"
+            "commit": "debe4c19d5182ed34809b75982c70d980a8c79e0"
         }
     ],
     "modules": [

--- a/addons/game.libretro.swanstation/game.libretro.swanstation.json
+++ b/addons/game.libretro.swanstation/game.libretro.swanstation.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.swanstation",
-            "commit": "17e8a9b6422e2d851aae1fe16b1c007bc7cc33d3"
+            "commit": "6913ec3b4235c08e6bf044a15b05d4d373c70510"
         }
     ],
     "modules": [

--- a/addons/game.libretro.tyrquake/game.libretro.tyrquake.json
+++ b/addons/game.libretro.tyrquake/game.libretro.tyrquake.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.tyrquake",
-            "commit": "d5a5283a13d82f50b5186e486620797a815a4d0d"
+            "commit": "0283cd519ea7f8cf0a8e73d0013597ecdd94b9ad"
         }
     ],
     "modules": [

--- a/addons/game.libretro.uae/game.libretro.uae.json
+++ b/addons/game.libretro.uae/game.libretro.uae.json
@@ -38,7 +38,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/libretro/libretro-uae",
-                    "commit": "788d21aa1b41b917a11e1aeb87f730b007d2b5f5"
+                    "commit": "96ebfcfc2c66233ad37f6dc99ee991211dc719ad"
                 }
             ]
         }

--- a/addons/game.libretro.uae/game.libretro.uae.json
+++ b/addons/game.libretro.uae/game.libretro.uae.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.uae",
-            "commit": "dc746fc198a3a5c2a4b3ef89d2baadef3a3ec5fe"
+            "commit": "2dc07a2fd792a41c35f620a7d12fe62a3efedf7d"
         }
     ],
     "modules": [

--- a/addons/game.libretro.vbam/game.libretro.vbam.json
+++ b/addons/game.libretro.vbam/game.libretro.vbam.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.vbam",
-            "commit": "89781679d04d1e2b406963288579795d92faed89"
+            "commit": "dae3ee31583ff0bc5ae381ee82200ec1eb0337cf"
         }
     ],
     "modules": [

--- a/addons/game.libretro.vbam/game.libretro.vbam.json
+++ b/addons/game.libretro.vbam/game.libretro.vbam.json
@@ -37,7 +37,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/visualboyadvance-m/visualboyadvance-m",
-                    "commit": "aead41eb2e6145907c9496835a42100920f26d12"
+                    "commit": "157eca385bc742ed26f0cbbd6adc9a9414a6f1ec"
                 }
             ]
         }

--- a/addons/game.libretro.virtualjaguar/game.libretro.virtualjaguar.json
+++ b/addons/game.libretro.virtualjaguar/game.libretro.virtualjaguar.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.virtualjaguar",
-            "commit": "b9579f841f0299bc685a31834a1ddaf440807f4a"
+            "commit": "3fea8f63529535fd077abaf9835ea688d4b69f46"
         }
     ],
     "modules": [

--- a/addons/game.libretro.virtualjaguar/game.libretro.virtualjaguar.json
+++ b/addons/game.libretro.virtualjaguar/game.libretro.virtualjaguar.json
@@ -36,7 +36,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/libretro/virtualjaguar-libretro",
-                    "commit": "cab0671a6741876f92f0873e201f15550e5a0995"
+                    "commit": "59f7f9cc594ae6c6982c2bd8fc0dbf36873f9869"
                 }
             ]
         }

--- a/addons/game.libretro/game.libretro.json
+++ b/addons/game.libretro/game.libretro.json
@@ -18,7 +18,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro",
-            "commit": "e01465001f4095cbab413f88a3769557e051d54f"
+            "commit": "79f0347a0759f486e03db266edc4be8bd32f199e"
         }
     ],
     "modules": [

--- a/addons/inputstream.adaptive/inputstream.adaptive.json
+++ b/addons/inputstream.adaptive/inputstream.adaptive.json
@@ -11,7 +11,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/inputstream.adaptive",
-            "commit": "0801282232050a8d9d67269ada71b88f795c6889"
+            "commit": "f00a8b1991981ee5b2f457ca49a1ef270208eeae"
         },
         {
             "type": "file",

--- a/addons/inputstream.ffmpegdirect/inputstream.ffmpegdirect.json
+++ b/addons/inputstream.ffmpegdirect/inputstream.ffmpegdirect.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/inputstream.ffmpegdirect",
-            "commit": "3a3a626124ad42d4dbb28a801a17116775fba11e"
+            "commit": "6c02cd986df473592cbcdb419cd7a357ba020f2c"
         }
     ],
     "build-options": {

--- a/addons/pvr.hts/pvr.hts.json
+++ b/addons/pvr.hts/pvr.hts.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.hts",
-            "commit": "ae5fb01d74e4003b35935490dd8474f9de8589ad"
+            "commit": "e58408a42322eb495bc54bc947847542c9f91188"
         }
     ],
     "build-options": {

--- a/addons/pvr.mythtv/pvr.mythtv.json
+++ b/addons/pvr.mythtv/pvr.mythtv.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/janbar/pvr.mythtv",
-            "commit": "4670e30687a88b147d44ff8225f4efbf7b0dddf1"
+            "commit": "bab072effff157c7352180b068940d3b2032be30"
         }
     ],
     "build-options": {

--- a/addons/pvr.waipu/pvr.waipu.json
+++ b/addons/pvr.waipu/pvr.waipu.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/flubshi/pvr.waipu",
-            "commit": "b0885de595d0fc655c11fd0046f637c223330ba0"
+            "commit": "f374e4a7080a618613a199dfc80aa4708502d419"
         }
     ],
     "build-options": {

--- a/addons/screensaver.asteroids/screensaver.asteroids.json
+++ b/addons/screensaver.asteroids/screensaver.asteroids.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/screensaver.asteroids",
-            "commit": "ab7aa97bbfbfe54c118cd19dcdb8f7b9b8102b97"
+            "commit": "4e1fb494b21f1fd7cac44c675128ea5cefa0ef4f"
         }
     ],
     "build-options": {

--- a/addons/screensaver.biogenesis/screensaver.biogenesis.json
+++ b/addons/screensaver.biogenesis/screensaver.biogenesis.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/screensaver.biogenesis",
-            "commit": "9d8a08ad8fb74bcc1cf8cf9df8c912a1c60a5dc2"
+            "commit": "096da8df47e9f058c04b14b2eaf68ad6937d698b"
         }
     ],
     "build-options": {

--- a/addons/screensaver.cpblobs/screensaver.cpblobs.json
+++ b/addons/screensaver.cpblobs/screensaver.cpblobs.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/screensaver.cpblobs",
-            "commit": "ac86ab042f9cacc00e6512cb8c71162e5bad28b2"
+            "commit": "e6a9902b9437a07cf62722f3a64f916ea8ce1ca9"
         }
     ],
     "build-options": {

--- a/addons/screensaver.matrixtrails/screensaver.matrixtrails.json
+++ b/addons/screensaver.matrixtrails/screensaver.matrixtrails.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/screensaver.matrixtrails",
-            "commit": "b7322bb2e9104a1e739bcfd3c565d15f6f07ec4f"
+            "commit": "bf5d5cf2e6f6c486bb58989dc387b5c9e2d086a9"
         }
     ],
     "build-options": {

--- a/addons/screensaver.pyro/screensaver.pyro.json
+++ b/addons/screensaver.pyro/screensaver.pyro.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/screensaver.pyro",
-            "commit": "52fcf0e65ba00e7313e9b473654b102258268891"
+            "commit": "d93f5f906f3cfa15b7931cc168ae1722859e9d87"
         }
     ],
     "build-options": {

--- a/addons/screensavers.rsxs/screensavers.rsxs.json
+++ b/addons/screensavers.rsxs/screensavers.rsxs.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/screensavers.rsxs",
-            "commit": "ceeee2852fe257b651e8c53eca6f98aab66dd599"
+            "commit": "704185a287c5c06a71306e94f280e45e476c4a36"
         }
     ],
     "build-options": {

--- a/addons/vfs.libarchive/vfs.libarchive.json
+++ b/addons/vfs.libarchive/vfs.libarchive.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/vfs.libarchive",
-            "commit": "926158ace31afbebca3a65c82973ac3edcd6c354"
+            "commit": "9fc2819a82697d1ac8f875aebb728e01ab2dc882"
         }
     ],
     "build-options": {

--- a/addons/vfs.rar/vfs.rar.json
+++ b/addons/vfs.rar/vfs.rar.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/vfs.rar",
-            "commit": "fdab4e5475a1038ae352e249c21e6b0a2540bae0"
+            "commit": "81a7e8321bd825ee9ad3f31b09cf26f187aa11b3"
         }
     ],
     "build-options": {

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -791,7 +791,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/xbmc/xbmc.git
-        commit: d9f9abaccee5b5a4998f80d39e4aa85ed3ecc819
+        commit: 700f5f80cf51b923b06f534014a16c237bb69cde
         x-checker-data:
           type: git
           tag-pattern: ^(\d+\.\d+(?:\w+)?(?:-\w+)?)$

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -125,8 +125,8 @@ modules:
       - /bin
     sources:
       - type: archive
-        url: https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n9.0.tar.gz
-        sha512: 4327d259b2ed9cc35a6139606643bf9c9db5fb0372a9eb259fed61af50505a2b59f0c3d94c51fec89d2e0cd552a413c5f50514683931c94c429824198d56ec56
+        url: https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n9.0.1.tar.gz
+        sha512: 41aa687cec4e93d0ffde21ea96faa48e4344fda0e9d2c9c71adfb68fedadf03beb274ec712eb1e082bf64fdcee87c55a47bb5c78d5193934be3f3f06e5e792b2
         x-checker-data:
           type: anitya
           project-id: 5405
@@ -306,8 +306,8 @@ modules:
       - --disable-example-progs
     sources:
       - type: archive
-        url: https://github.com/libcdio/libcdio/releases/download/2.3.0/libcdio-2.3.0.tar.bz2
-        sha256: 53e83d284667535a767fd2d31edad1a6701591960459df373a10f1f21e80a7ed
+        url: https://github.com/libcdio/libcdio/releases/download/2.4.0/libcdio-2.4.0.tar.bz2
+        sha256: 8e6a305f81e45a78b41ce696d34497cc208d97075469d7304c11a6d44bf006ac
         x-checker-data:
           type: anitya
           project-id: 1573
@@ -560,8 +560,8 @@ modules:
         PERL5LIB: /app/lib/perl5
     sources:
       - type: archive
-        url: https://download.samba.org/pub/samba/stable/samba-4.24.5.tar.gz
-        sha256: 6d5d7ee82f5ce9da4135086c9b184e47a58b4b023565f58abbb1f8c8a922306b
+        url: https://download.samba.org/pub/samba/stable/samba-4.24.6.tar.gz
+        sha256: 810cc955acb367e9bde556dccfb50db177a02b7c553aa1629a0b905fa7616267
         x-checker-data:
           type: anitya
           project-id: 4758
@@ -846,7 +846,8 @@ modules:
       - type: shell
         commands:
           - mkdir -p /app/tarballs
-          - mv build/download/*.tar.gz build/download/*.tar.xz build/download/*.zip /app/tarballs/
+          - mv build/download/*.tar.gz build/download/*.tar.xz build/download/*.zip
+            /app/tarballs/
     cleanup:
       - /tarballs
 

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -782,9 +782,12 @@ modules:
       - -DAPP_RENDER_SYSTEM=gles
       - -DJava_JAVA_EXECUTABLE=/usr/lib/sdk/openjdk17/bin/java
       - -DCROSSGUID_URL=/app/tarballs/crossguid.tar.gz
-      - -DLIBDVDCSS_URL=/app/tarballs/libdvdcss.tar.bz2
-      - -DLIBDVDREAD_URL=/app/tarballs/libdvdread.tar.bz2
-      - -DLIBDVDNAV_URL=/app/tarballs/libdvdnav.tar.bz2
+      - -DLIBDVDCSS_URL=/app/tarballs/libdvdcss.tar.xz
+      - -DLIBDVDCSS_HASH=SHA512=edd8b00af2621d1b8fb7eac818e9e7a763aabb1b2868d2fc56836b8a22d6d6bc1855b027125557263a6607c86e5d32214b86ab4e22ecb6ca51964abd22574ea0
+      - -DLIBDVDREAD_URL=/app/tarballs/libdvdread.tar.xz
+      - -DLIBDVDREAD_HASH=SHA512=03e7376327ba211fcc51ee4e4705b1cc7649c613a96e186eb62821b57a11a519c46720e33cf3351cd95fa02db200e40d3b1b9f7e4fe5a3003853fc40c5f511f0
+      - -DLIBDVDNAV_URL=/app/tarballs/libdvdnav.tar.xz
+      - -DLIBDVDNAV_HASH=SHA512=4df6336050f3b79ca2edafac28dd0383b950272ba6d8ebe6e43a85eddc737ce740d72a3fc1fa03c26fc5f285125e3672a022555a5399259386b2036c467a47f3
       - -DTARBALL_DIR=/app/tarballs
     sources:
       - type: git
@@ -812,20 +815,20 @@ modules:
         dest: build/download/
         dest-filename: crossguid.tar.gz
       - type: file
-        url: http://mirrors.kodi.tv/build-deps/sources/libdvdcss-1.5.0.tar.bz2
-        sha512: 439fbd9dae60b9a114d3429a19703478c734e8525ac6852da6f05f72d9ca44ca0ac5e874ab6a10017e7f31869fcd29f01d1bc156c4f0331b4e4abd98ec2f95cd
+        url: https://download.videolan.org/pub/videolan/libdvdcss/1.5.0/libdvdcss-1.5.0.tar.xz
+        sha512: edd8b00af2621d1b8fb7eac818e9e7a763aabb1b2868d2fc56836b8a22d6d6bc1855b027125557263a6607c86e5d32214b86ab4e22ecb6ca51964abd22574ea0
         dest: build/download/
-        dest-filename: libdvdcss.tar.bz2
+        dest-filename: libdvdcss.tar.xz
       - type: file
-        url: http://mirrors.kodi.tv/build-deps/sources/libdvdread-7.0.1.tar.bz2
-        sha512: b5390a1acb8fdf6e24188f9259199eb0fef2dd4b332447ba2bfa571f9fc0c3bfad00c1d27a8b8806180a853c04a818b7802d3075ff787142c1a175ad798c6a3d
+        url: https://download.videolan.org/pub/videolan/libdvdread/7.0.1/libdvdread-7.0.1.tar.xz
+        sha512: 03e7376327ba211fcc51ee4e4705b1cc7649c613a96e186eb62821b57a11a519c46720e33cf3351cd95fa02db200e40d3b1b9f7e4fe5a3003853fc40c5f511f0
         dest: build/download/
-        dest-filename: libdvdread.tar.bz2
+        dest-filename: libdvdread.tar.xz
       - type: file
-        url: http://mirrors.kodi.tv/build-deps/sources/libdvdnav-7.0.0.tar.bz2
-        sha512: 8d12d476e352def9716ecbd7ba184a70dd9bae87dcde669b8647a0ef9ac1991f617c9918c043e159eb353302c4cc50fb71bc591ceaeba1d3b9d47af77fa72c71
+        url: https://download.videolan.org/pub/videolan/libdvdnav/7.0.0/libdvdnav-7.0.0.tar.xz
+        sha512: 4df6336050f3b79ca2edafac28dd0383b950272ba6d8ebe6e43a85eddc737ce740d72a3fc1fa03c26fc5f285125e3672a022555a5399259386b2036c467a47f3
         dest: build/download/
-        dest-filename: libdvdnav.tar.bz2
+        dest-filename: libdvdnav.tar.xz
       - type: file
         url: https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-4.0.30.zip
         sha512: 789e956ecad3c302d545a16caccd45454357556b566ee83abfafe102371cf218f5ed5dc83d748595fbb2d465bde6c7306a498806e58b512cfc742abe5f5b101d
@@ -844,7 +847,7 @@ modules:
       - type: shell
         commands:
           - mkdir -p /app/tarballs
-          - mv build/download/*.tar.gz build/download/*.tar.bz2 build/download/*.zip /app/tarballs/
+          - mv build/download/*.tar.gz build/download/*.tar.xz build/download/*.zip /app/tarballs/
     cleanup:
       - /tarballs
 

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -288,8 +288,8 @@ modules:
       - /bin
     sources:
       - type: archive
-        url: https://github.com/Pulse-Eight/libcec/archive/libcec-8.1.3.tar.gz
-        sha256: c7b208433418991a9ae7af1d43ffebf99ddc27ee7119a2794f19dcc02e4568b1
+        url: https://github.com/Pulse-Eight/libcec/archive/libcec-8.1.6.tar.gz
+        sha256: e1e762fee8589def3cbceb1f3e53ba06ed5b557a2705b86a225f8f30fb19c79a
         x-checker-data:
           type: anitya
           project-id: 21468
@@ -366,8 +366,8 @@ modules:
       - --disable-static
     sources:
       - type: archive
-        url: https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-1.0.9.tar.gz
-        sha256: 6e9adc446b08083ec03d40317fb66ca6f2e03e4f6170aef33a6e59bb08db2012
+        url: https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-1.0.10.tar.gz
+        sha256: 04bfe8ef75db7d629a33de767599765cecadc56274a39822d5d081030d577685
         x-checker-data:
           type: anitya
           project-id: 1658
@@ -381,8 +381,8 @@ modules:
       - /bin
     sources:
       - type: archive
-        url: https://github.com/sahlberg/libnfs/archive/libnfs-6.0.2.tar.gz
-        sha512: 539790ab98aac7b2f25755b745d1f5e016518f1adb3748b8c58df187048bc31e091915d59e6359bb95c49dd986361cbbf2536edcda02598b0fac236762b61a46
+        url: https://github.com/sahlberg/libnfs/archive/libnfs-7.0.0.tar.gz
+        sha512: 16464129a827af897af35120d8b495993ea9bc56889fa815230e6fd999f391834256a83f3b58060b4c8e0c5d0608e2ca76f3716cff05ca15c40551a2be4aa8ad
         x-checker-data:
           type: anitya
           project-id: 7325
@@ -456,8 +456,8 @@ modules:
         ${FLATPAK_DEST}/share/licenses/tv.kodi.Kodi/python3-pybind11/LICENSE
     sources:
       - type: file
-        url: https://files.pythonhosted.org/packages/b3/06/c3a23c9a0263b136c519f033a58d4641e73065fefc7754e9667ec206d992/pybind11-3.0.4-py3-none-any.whl
-        sha256: 961720ee652da51d531b7b2451a6bd2bc042b0106e6d9baa48ecb7d58034ce63
+        url: https://files.pythonhosted.org/packages/33/fd/8762f7ee3e4e4be6d1d846cffb4916dd9bb02b2f800d3603718a0efe494c/pybind11-3.1.0-py3-none-any.whl
+        sha256: b8488090f8acffbcb6b5d6a85571a6827a0a2981ffb75e5a0b27b87c4a6b7dd0
         x-checker-data:
           type: json
           url: https://pypi.org/pypi/pybind11/json
@@ -621,8 +621,8 @@ modules:
       - /share/swig
     sources:
       - type: archive
-        url: http://prdownloads.sourceforge.net/swig/swig-4.4.1.tar.gz
-        sha256: 40162a706c56f7592d08fd52ef5511cb7ac191f3593cf07306a0a554c6281fcf
+        url: http://prdownloads.sourceforge.net/swig/swig-4.5.0.tar.gz
+        sha256: 22ae0e887f8cca8031a325c67d005207653200b40e71edb3f88780e28e47d0ff
         x-checker-data:
           type: anitya
           project-id: 4919

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -95,15 +95,15 @@ modules:
       - /bin
     sources:
       - type: archive
-        url: https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n8.1.2.tar.gz
-        sha512: c72f4062aecc16d8b2b1e8678d5efe3af4cfaa0cc7c0997052248f9e499e60c2463acf07877cf3b78b246ce3e8078cb043e8d97e90a6b50d06af32ff7369a788
+        url: https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n9.0.tar.gz
+        sha512: 4327d259b2ed9cc35a6139606643bf9c9db5fb0372a9eb259fed61af50505a2b59f0c3d94c51fec89d2e0cd552a413c5f50514683931c94c429824198d56ec56
         x-checker-data:
           type: anitya
           project-id: 5405
           url-template: https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n$version.tar.gz
       - type: file
-        url: https://raw.githubusercontent.com/xbmc/xbmc/c4913a2c601c44b44ce24b7f8decb981adedccdf/tools/depends/target/ffmpeg/001-ffmpeg-all-libpostproc-plugin.patch
-        sha256: ef4db98503c1303c9240fc4774d338c8460979c9948391cb6f0c5b27f512508b
+        url: https://raw.githubusercontent.com/xbmc/xbmc/bc56c2fcd679a9bbb8c9d13b505a6c7285f7206c/tools/depends/target/ffmpeg/001-ffmpeg-all-libpostproc-plugin.patch
+        sha256: 019ab331eac814e4995c65dcc8076cc433a64bb4a5d2aa6aef5516922dd691e6
         dest-filename: 001-ffmpeg-all-libpostproc-plugin.patch
       - type: shell
         commands:

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -55,6 +55,36 @@ cleanup:
   - /share/man
   - /var
 modules:
+  - name: avahi
+    cleanup:
+      - /bin
+      - /share/runtime/locale
+    config-opts:
+      - --enable-shared
+      - --disable-static
+      - --with-distro=none
+      - --disable-libdaemon
+      - --disable-libsystemd
+      - --disable-nls
+      - --disable-core-docs
+      - --disable-manpages
+      - --disable-mono
+      - --disable-libevent
+      - --disable-qt4
+      - --disable-qt5
+      - --disable-python
+      - --disable-gtk
+      - --disable-gtk3
+      - --enable-compat-libdns_sd
+    sources:
+      - type: archive
+        url: https://github.com/avahi/avahi/archive/refs/tags/v0.9-rc5.tar.gz
+        sha256: 5b0a9d88110b0fc8aaafc5cc0a26e83e7d2a4aca3a36bc27c9b626db7ead27b0
+        x-checker-data:
+          type: anitya
+          project-id: 147
+          url-template: https://github.com/avahi/avahi/archive/refs/tags/v$version.tar.gz
+          stable-only: false
   - name: dav1d
     buildsystem: meson
     config-opts:
@@ -564,37 +594,6 @@ modules:
       - type: git
         url: https://github.com/juhovh/shairplay/
         commit: 096b61ad14c90169f438e690d096e3fcf87e504e
-    modules:
-      - name: avahi
-        cleanup:
-          - /bin
-          - /share/runtime/locale
-        config-opts:
-          - --enable-shared
-          - --disable-static
-          - --with-distro=none
-          - --disable-libdaemon
-          - --disable-libsystemd
-          - --disable-nls
-          - --disable-core-docs
-          - --disable-manpages
-          - --disable-mono
-          - --disable-libevent
-          - --disable-qt4
-          - --disable-qt5
-          - --disable-python
-          - --disable-gtk
-          - --disable-gtk3
-          - --enable-compat-libdns_sd
-        sources:
-          - type: archive
-            url: https://github.com/avahi/avahi/archive/refs/tags/v0.9-rc5.tar.gz
-            sha256: 5b0a9d88110b0fc8aaafc5cc0a26e83e7d2a4aca3a36bc27c9b626db7ead27b0
-            x-checker-data:
-              type: anitya
-              project-id: 147
-              url-template: https://github.com/avahi/avahi/archive/refs/tags/v$version.tar.gz
-              stable-only: false
   - name: spdlog
     buildsystem: cmake-ninja
     config-opts:


### PR DESCRIPTION
- ffmpeg: update to 9.0.
- inputstream.ffmpegdirect: patch to build against ffmpeg 9.
  `AVCodecParser.parser_parse` is now private; use the public
  `av_parser_parse2()`, as kodi core already does (xbmc/inputstream.ffmpegdirect#381).
  Patch submitted upstream (xbmc/inputstream.ffmpegdirect/pull/382).
  Patch folded into upstream (https://github.com/xbmc/inputstream.ffmpegdirect/commit/6c02cd986df473592cbcdb419cd7a357ba020f2c).
- libdvd: fetch libdvdcss/libdvdread/libdvdnav tarballs from
  download.videolan.org instead of the kodi mirror. Upstream only
  publishes xz, so the matching `*_HASH` values are passed to kodi's
  cmake — it verifies the recorded bz2 hash otherwise, even for a
  local tarball.
- avahi: move from a nested shairplay dependency to a top-level module.
  kodi links libavahi-client/libavahi-common directly for Zeroconf.
  shairplay never links it at all — it only needs the compat headers to
  build, then dlopens libdns_sd.so.
- kodi: update to githash 700f5f8.
- addons: update to latest upstream.
- addons: second pass bumping 16 libretro cores to latest upstream.
- fedc: update libcec 8.1.6, pybind11 3.1.0, swig 4.5.0,
  libmicrohttpd 1.0.10, libnfs 7.0.0, samba 4.24.6, ffmpeg 9.0.1, libcdio 2.3.0.