### PR TITLE
DO NOT MERGE: test RetroPlayer hardware rendering PR stack

### DIFF
--- a/addon-list.txt
+++ b/addon-list.txt
@@ -45,6 +45,7 @@ game.libretro.bk
 game.libretro.blastem
 game.libretro.bluemsx
 game.libretro.cap32
+game.libretro.dolphin
 game.libretro.dosbox
 game.libretro.dosbox-pure
 game.libretro.fceumm
@@ -52,6 +53,7 @@ game.libretro.fuse
 game.libretro.gambatte
 game.libretro.gw
 game.libretro.handy
+game.libretro.melonds
 game.libretro.mesen
 game.libretro.mesen-s
 game.libretro.mrboom
@@ -72,6 +74,7 @@ game.libretro.uae
 game.libretro.vbam
 game.libretro.vecx
 game.libretro.virtualjaguar
+game.libretro.yabasanshiro
 game.libretro.yabause
 game.shader.presets
 imagedecoder.heif

--- a/addons/game.libretro.dolphin/game.libretro.dolphin.json
+++ b/addons/game.libretro.dolphin/game.libretro.dolphin.json
@@ -1,0 +1,231 @@
+{
+    "name": "game.libretro.dolphin",
+    "buildsystem": "cmake-ninja",
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
+    ],
+    "sources": [
+        {
+            "type": "git",
+            "url": "https://github.com/kodi-game/game.libretro.dolphin",
+            "commit": "88d5c8009e4c81700b4a711f69d032459939cce7"
+        }
+    ],
+    "modules": [
+        {
+            "name": "enet",
+            "config-opts": [
+                "--enable-shared",
+                "--disable-static"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/lsalzman/enet/archive/refs/tags/v1.3.18.tar.gz",
+                    "sha256": "28603c895f9ed24a846478180ee72c7376b39b4bb1287b73877e5eae7d96b0dd",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 696,
+                        "url-template": "https://github.com/lsalzman/enet/archive/refs/tags/v$version.tar.gz"
+                    }
+                },
+                {
+                    "type": "script",
+                    "dest-filename": "autogen.sh",
+                    "commands": [
+                        "autoreconf -vfi"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "libspng",
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Ddefault_library=shared",
+                "-Dbuild_examples=false"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/randy408/libspng/archive/refs/tags/v0.7.4.tar.gz",
+                    "sha256": "47ec02be6c0a6323044600a9221b049f63e1953faf816903e7383d4dc4234487",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 24289,
+                        "url-template": "https://github.com/randy408/libspng/archive/refs/tags/v$version.tar.gz"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "minizip-ng",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DBUILD_SHARED_LIBS=ON",
+                "-DMZ_COMPAT=OFF",
+                "-DMZ_PPMD=OFF",
+                "-DMZ_BUILD_TESTS=OFF",
+                "-DMZ_FETCH_LIBS=OFF",
+                "-DCMAKE_INSTALL_LIBDIR=lib"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/zlib-ng/minizip-ng/archive/refs/tags/4.2.2.tar.gz",
+                    "sha256": "71af7b9799856d8b03619df3949e9c1be9703f8de0795af71399ba283cb27aac",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 301509,
+                        "url-template": "https://github.com/zlib-ng/minizip-ng/archive/refs/tags/$version.tar.gz"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "mbedtls",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
+                "-DUSE_SHARED_MBEDTLS_LIBRARY=ON",
+                "-DUSE_STATIC_MBEDTLS_LIBRARY=OFF",
+                "-DENABLE_TESTING=OFF",
+                "-DENABLE_PROGRAMS=OFF"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/v2.28.10.tar.gz",
+                    "sha256": "0f2e0525903a89ae1d39ce439d858be66933bda54c5b6102b72a29ed8fe7c088",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 13824,
+                        "url-template": "https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/v$version.tar.gz",
+                        "versions": {
+                            "<": "3"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "sfml",
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DBUILD_SHARED_LIBS=ON",
+                "-DSFML_BUILD_WINDOW=OFF",
+                "-DSFML_BUILD_GRAPHICS=OFF",
+                "-DSFML_BUILD_AUDIO=OFF",
+                "-DCMAKE_INSTALL_LIBDIR=lib"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/SFML/SFML/archive/refs/tags/3.0.2.tar.gz",
+                    "sha256": "0034e05f95509e5d3fb81b1625713e06da7b068f210288ce3fd67106f8f46995",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 12315,
+                        "stable-only": true,
+                        "url-template": "https://github.com/SFML/SFML/archive/refs/tags/$version.tar.gz",
+                        "versions": {
+                            "<": "3.1"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "hidapi",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DBUILD_SHARED_LIBS=ON",
+                "-DCMAKE_INSTALL_LIBDIR=lib"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/libusb/hidapi/archive/refs/tags/hidapi-0.15.0.tar.gz",
+                    "sha256": "5d84dec684c27b97b921d2f3b73218cb773cf4ea915caee317ac8fc73cef8136",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 5594,
+                        "url-template": "https://github.com/libusb/hidapi/archive/refs/tags/hidapi-$version.tar.gz"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "libretro-dolphin",
+            "buildsystem": "simple",
+            "build-options": {
+                "no-debuginfo": true,
+                "cflags": "-g0",
+                "cxxflags": "-g0"
+            },
+            "build-commands": [
+                "cmake -S . -B Build -G Ninja -DCMAKE_INSTALL_PREFIX=/app -DCMAKE_BUILD_TYPE=Release -DLIBRETRO=ON -DUSE_SYSTEM_LIBS=ON -DENABLE_VULKAN=OFF -DENABLE_X11=OFF -DENABLE_EGL=ON",
+                "cmake --build Build -j$FLATPAK_BUILDER_N_JOBS",
+                "install -D -m 755 Build/dolphin_libretro.so /app/lib/libretro/dolphin_libretro.so",
+                "mkdir -p /app/share/kodi/addons/game.libretro.dolphin/resources/system/dolphin-emu",
+                "cp -a Data/Sys /app/share/kodi/addons/game.libretro.dolphin/resources/system/dolphin-emu/Sys"
+            ],
+            "cleanup": [
+                "/lib/libretro"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/libretro/dolphin/archive/0cd3bb89c29535db9b7552fc86871867ccf5b471.tar.gz",
+                    "sha256": "c8e7cb4bf68facc3d781d14209c678d6e14f857288bdd41c0ece1fa8195d393a"
+                },
+                {
+                    "type": "archive",
+                    "url": "https://github.com/ocornut/imgui/archive/45acd5e0e82f4c954432533ae9985ff0e1aad6d5.tar.gz",
+                    "sha256": "97484925aec2f4d3e913d6644d46b234f8d6d8d98c6aa9c50109e0f0df772090",
+                    "dest": "Externals/imgui/imgui"
+                },
+                {
+                    "type": "archive",
+                    "url": "https://github.com/epezent/implot/archive/3da8bd34299965d3b0ab124df743fe3e076fa222.tar.gz",
+                    "sha256": "4700b44ef00ca2feba0b35a31922c240045bbeb900da5b3eb3830b56871ada45",
+                    "dest": "Externals/implot/implot"
+                },
+                {
+                    "type": "archive",
+                    "url": "https://github.com/syoyo/tinygltf/archive/c5641f2c22d117da7971504591a8f6a41ece488b.tar.gz",
+                    "sha256": "6352803f1ed18d479ea93abf96ac75c0222a21403be22840bde1072ee5935dfa",
+                    "dest": "Externals/tinygltf/tinygltf"
+                },
+                {
+                    "type": "archive",
+                    "url": "https://github.com/e-dant/watcher/archive/b03bdcfc11549df595b77239cefe2643943a3e2f.tar.gz",
+                    "sha256": "61e97c12c3d23f2b6588d99ce61c8ad462b4382f979d14c7a338a11af507edd1",
+                    "dest": "Externals/watcher/watcher"
+                },
+                {
+                    "type": "archive",
+                    "url": "https://github.com/mutouyun/cpp-ipc/archive/ce0773b3e6d5abaa8d104100c5704321113853ca.tar.gz",
+                    "sha256": "01613a09deb56de754d5f3b284cb7d21c7286dbb61cd148f26515b1a0bd04d79",
+                    "dest": "Externals/cpp-ipc/cpp-ipc"
+                },
+                {
+                    "type": "archive",
+                    "url": "https://github.com/weisslj/cpp-optparse/archive/2265d647232249a53a03b411099863ceca35f0d3.tar.gz",
+                    "sha256": "6f38fff3c4d2788eead7a28626b3220cc4c101510fc984678ad55f77756b107e",
+                    "dest": "Externals/cpp-optparse/cpp-optparse"
+                }
+            ]
+        }
+    ]
+}

--- a/addons/game.libretro.melonds/game.libretro.melonds.json
+++ b/addons/game.libretro.melonds/game.libretro.melonds.json
@@ -1,0 +1,49 @@
+{
+    "name": "game.libretro.melonds",
+    "buildsystem": "cmake-ninja",
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
+    ],
+    "sources": [
+        {
+            "type": "git",
+            "url": "https://github.com/kodi-game/game.libretro.melonds",
+            "commit": "5362e7fe843fda19199036691346a47e07881ab8"
+        }
+    ],
+    "modules": [
+        {
+            "name": "libretro-melonds",
+            "buildsystem": "simple",
+            "build-options": {
+                "no-debuginfo": true,
+                "cflags": "-g0",
+                "cxxflags": "-g0",
+                "ldflags": "-Wl,-z,noexecstack"
+            },
+            "build-commands": [
+                "make -j$FLATPAK_BUILDER_N_JOBS PREFIX=/app platform=unix DISABLE_OPENGL=1",
+                "install -D -m 755 melonds_libretro.so /app/lib/libretro/melonds_libretro.so"
+            ],
+            "cleanup": [
+                "/lib/libretro"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/libretro/melonDS",
+                    "commit": "66b5d2634cd0a79030562811e6e05f5532f800ba"
+                },
+                {
+                    "type": "patch",
+                    "path": "libretro-melonds-001-allow-building-without-opengl.patch"
+                }
+            ]
+        }
+    ]
+}

--- a/addons/game.libretro.melonds/libretro-melonds-001-allow-building-without-opengl.patch
+++ b/addons/game.libretro.melonds/libretro-melonds-001-allow-building-without-opengl.patch
@@ -1,0 +1,23 @@
+melonDS hard-links -lGL on x86, so it cannot be built for a system that only
+provides OpenGL ES. Its OpenGL renderer is desktop-GL only -- Makefile.common
+gates it on HAVE_OPENGL and pulls glsym_gl.c -- so add DISABLE_OPENGL and build
+the software renderer alone.
+
+Submitted upstream: https://github.com/libretro/melonDS/pull/215
+
+diff --git a/Makefile b/Makefile
+--- a/Makefile
++++ b/Makefile
+@@ -80,8 +80,10 @@ ifeq ($(platform), unix)
+    endif
+    HAVE_THREADS=1
+    ifneq ($(filter $(ARCH),x86 x86_64),)
+-     LIBS += -lGL
+-     HAVE_OPENGL=1
++     ifneq ($(DISABLE_OPENGL), 1)
++       LIBS += -lGL
++       HAVE_OPENGL=1
++     endif
+    endif
+    ifeq ($(ARCH),x86_64)
+       JIT_ARCH=x64

--- a/addons/game.libretro.yabasanshiro/game.libretro.yabasanshiro.json
+++ b/addons/game.libretro.yabasanshiro/game.libretro.yabasanshiro.json
@@ -1,0 +1,56 @@
+{
+    "name": "game.libretro.yabasanshiro",
+    "buildsystem": "cmake-ninja",
+    "build-options": {
+        "no-debuginfo": true,
+        "cflags": "-g0",
+        "cxxflags": "-g0"
+    },
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
+    ],
+    "sources": [
+        {
+            "type": "git",
+            "url": "https://github.com/kodi-game/game.libretro.yabasanshiro",
+            "commit": "cc1bf930f02764087522fd413435960015d54dbe"
+        }
+    ],
+    "modules": [
+        {
+            "name": "libretro-yabasanshiro",
+            "buildsystem": "simple",
+            "build-options": {
+                "no-debuginfo": true,
+                "cflags": "-g0",
+                "cxxflags": "-g0",
+                "arch": {
+                    "x86_64": {
+                        "env": {
+                            "ARCH_FLAGS": "HAVE_SSE=1"
+                        }
+                    },
+                    "aarch64": {
+                        "env": {
+                            "ARCH_FLAGS": "HAVE_SSE=0"
+                        }
+                    }
+                }
+            },
+            "build-commands": [
+                "make -j$FLATPAK_BUILDER_N_JOBS PREFIX=/app platform=unix FORCE_GLES=1 $ARCH_FLAGS -C yabause/src/libretro",
+                "install -D -m 755 yabause/src/libretro/yabasanshiro_libretro.so /app/lib/libretro/yabasanshiro_libretro.so"
+            ],
+            "cleanup": [
+                "/lib/libretro"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/libretro/yabause",
+                    "commit": "f448097b69a6037246a08e9dc09eabaa420d7893"
+                }
+            ]
+        }
+    ]
+}

--- a/addons/game.libretro/game.libretro.json
+++ b/addons/game.libretro/game.libretro.json
@@ -17,8 +17,8 @@
     "sources": [
         {
             "type": "git",
-            "url": "https://github.com/kodi-game/game.libretro",
-            "commit": "79f0347a0759f486e03db266edc4be8bd32f199e"
+            "url": "https://github.com/sunlollyking/game.libretro",
+            "commit": "893c7b8486138ac6756ccf90f95b2d92b92fc574"
         }
     ],
     "modules": [
@@ -33,12 +33,12 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/libretro/libretro-common/archive/a08b2b574787408abbb4ba34faf673117f9a0eae.tar.gz",
-                    "sha256": "448c6531e32783835fc900e1dffcf621ad2d0e29134f1e6645e2ee2a3132038f"
+                    "url": "https://github.com/libretro/libretro-common/archive/55ca668901e72eb885976c8c839e6903ecbb119d.tar.gz",
+                    "sha256": "f2bc6311bd1a62bf86207dbd6e6e78507350eedf411e4b31597e4a7555f022f1"
                 },
                 {
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/kodi-game/game.libretro/d04890600f5be1004056d42a936335de92d24b1f/depends/common/libretro-common/CMakeLists.txt",
+                    "url": "https://raw.githubusercontent.com/sunlollyking/game.libretro/893c7b8486138ac6756ccf90f95b2d92b92fc574/depends/common/libretro-common/CMakeLists.txt",
                     "sha256": "e45d4f77e57478ba27e6bcfcab2f7b641061cea24efd836e3d082e45cd0b688f"
                 }
             ]
@@ -54,19 +54,13 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/RetroAchievements/rcheevos/archive/v12.4.0.tar.gz",
-                    "sha256": "7fb1a43b8edfe727219d054ed868cc985bca54f331f9c2410f818dd3143df5d3",
-                    "x-checker-data": {
-                        "type": "json",
-                        "url": "https://api.github.com/repos/RetroAchievements/rcheevos/releases/latest",
-                        "version-query": ".tag_name",
-                        "url-query": "\"https://github.com/RetroAchievements/rcheevos/archive/\" + .tag_name + \".tar.gz\""
-                    }
+                    "url": "https://github.com/RetroAchievements/rcheevos/archive/v12.3.0.tar.gz",
+                    "sha256": "bc7ab9985aee7b6a29e3d65492de9371c866236c5873a1c4493ec9cb6d2603d2"
                 },
                 {
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/kodi-game/game.libretro/e01465001f4095cbab413f88a3769557e051d54f/depends/common/rcheevos/CMakeLists.txt",
-                    "sha256": "5a49ce4c200b2c9a6c2ce0e854c8c0530a7920e71e0eca5285962b0928f14563"
+                    "url": "https://raw.githubusercontent.com/sunlollyking/game.libretro/893c7b8486138ac6756ccf90f95b2d92b92fc574/depends/common/rcheevos/CMakeLists.txt",
+                    "sha256": "b2c66b8b19dc99953c6303a6ce8100ae5e88777a22516d2640b8334a511c1bdd"
                 }
             ]
         }

--- a/addons/vfs.sftp/vfs.sftp.json
+++ b/addons/vfs.sftp/vfs.sftp.json
@@ -29,13 +29,13 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://git.libssh.org/projects/libssh.git/snapshot/libssh-0.12.2.tar.gz",
-                    "sha256": "6d3c4025c746dd31571f1e241d4c15e4e23a4c45fc2b725fdec42b678d7205c5",
+                    "url": "https://www.libssh.org/files/0.12/libssh-0.12.2.tar.xz",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 1729,
-                        "url-template": "https://git.libssh.org/projects/libssh.git/snapshot/libssh-$version.tar.gz"
-                    }
+                        "url-template": "https://www.libssh.org/files/$major.$minor/libssh-$version.tar.xz"
+                    },
+                    "sha256": "49560f677d96e3706a904ac2de1116e25f3680937d51e5c92198fcba4a1c1e9f"
                 }
             ]
         }

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -12,6 +12,7 @@ desktop-file-name-suffix: ' (Beta)'
 finish-args:
   - --device=all
   - --allow=bluetooth
+  - --filesystem=xdg-download:ro
   - --filesystem=xdg-music
   - --filesystem=xdg-pictures
   - --filesystem=xdg-videos

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -913,6 +913,7 @@ modules:
   - addons/game.libretro.blastem/game.libretro.blastem.json
   - addons/game.libretro.bluemsx/game.libretro.bluemsx.json
   - addons/game.libretro.cap32/game.libretro.cap32.json
+  - addons/game.libretro.dolphin/game.libretro.dolphin.json
   - addons/game.libretro.dosbox/game.libretro.dosbox.json
   - addons/game.libretro.dosbox-pure/game.libretro.dosbox-pure.json
   - addons/game.libretro.fceumm/game.libretro.fceumm.json
@@ -920,6 +921,7 @@ modules:
   - addons/game.libretro.gambatte/game.libretro.gambatte.json
   - addons/game.libretro.gw/game.libretro.gw.json
   - addons/game.libretro.handy/game.libretro.handy.json
+  - addons/game.libretro.melonds/game.libretro.melonds.json
   - addons/game.libretro.mesen/game.libretro.mesen.json
   - addons/game.libretro.mesen-s/game.libretro.mesen-s.json
   - addons/game.libretro.mrboom/game.libretro.mrboom.json
@@ -940,6 +942,7 @@ modules:
   - addons/game.libretro.vbam/game.libretro.vbam.json
   - addons/game.libretro.vecx/game.libretro.vecx.json
   - addons/game.libretro.virtualjaguar/game.libretro.virtualjaguar.json
+  - addons/game.libretro.yabasanshiro/game.libretro.yabasanshiro.json
   - addons/game.libretro.yabause/game.libretro.yabause.json
   - addons/game.shader.presets/game.shader.presets.json
   - addons/imagedecoder.heif/imagedecoder.heif.json

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -791,8 +791,8 @@ modules:
       - -DTARBALL_DIR=/app/tarballs
     sources:
       - type: git
-        url: https://github.com/xbmc/xbmc.git
-        commit: 700f5f80cf51b923b06f534014a16c237bb69cde
+        url: https://github.com/sunlollyking/xbmc.git
+        commit: d64fa22f0a568854b117a97cb14b57c88a56b2c5
         x-checker-data:
           type: git
           tag-pattern: ^(\d+\.\d+(?:\w+)?(?:-\w+)?)$


### PR DESCRIPTION
**DO NOT MERGE — CI test only.**

Builds Kodi from garbear/xbmc#151 (RetroPlayer GL/GLES hardware rendering) and game.libretro from kodi-game/game.libretro#164 (Game API 7.0.0), to exercise the stack on aarch64 CI. Also carries two standalone improvements (read-only xdg-download access, dolphin Sys data bundling) that will be proposed separately.

Verified at runtime on x86_64 (AMD Radeon 880M, Mesa GLES 3.2, Wayland): dolphin negotiates an OpenGL ES 3.2 context through RetroPlayer's hardware rendering path and GameCube games are fully playable with a gamepad. aarch64 is build-tested only via this PR.
