### PR TITLE
align libretro core pins with addon depends files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,9 @@
 PROJECT ?= tv.kodi.Kodi
 
-.PHONY: update-addons update-addon-modules addon-list build flatpak install run clean
+.PHONY: update-addons addon-list build flatpak install run clean
 
 update-addons:
 	cd tools && uv run addon_updater.py -r
-	$(MAKE) addon-list
-# bump addon dependency modules to latest githash, all of them or
-# ADDONS="<addon id> ..."
-update-addon-modules:
-	cd tools && uv run addon_updater.py -r --modules $(ADDONS)
 	$(MAKE) addon-list
 addon-list:
 	for d in addons/*/; do id=$${d#addons/}; id=$${id%/}; \

--- a/addons/game.libretro.2048/game.libretro.2048.json
+++ b/addons/game.libretro.2048/game.libretro.2048.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.2048",
-            "commit": "ff8676ef8a1ae24119774213c2feed8b9c94f130"
+            "commit": "d6af9b50323d0da3b684ab75ee63f092b0b839a3"
         }
     ],
     "modules": [
@@ -26,9 +26,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/libretro/libretro-2048",
-                    "commit": "c90437d3c3913999624deca3fb55ecfa632b72c4"
+                    "type": "archive",
+                    "url": "https://github.com/libretro/libretro-2048/archive/c90437d3c3913999624deca3fb55ecfa632b72c4.tar.gz",
+                    "sha256": "e60494b1b9b5483227c1f1c3cc06bddba256e9f82c9d6fa7abb1e7b31239f554"
                 }
             ]
         }

--- a/addons/game.libretro.a5200/game.libretro.a5200.json
+++ b/addons/game.libretro.a5200/game.libretro.a5200.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.a5200",
-            "commit": "1ee9d0e387ff15513e406c90f05f7e9ef45ca2d8"
+            "commit": "ba3b17a7437c216b612b3370d400a71a99e184b4"
         }
     ],
     "modules": [
@@ -34,9 +34,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/libretro/a5200",
-                    "commit": "40c6f2f1ad4a3145b328d5baaf010fae6c7e752b"
+                    "type": "archive",
+                    "url": "https://github.com/libretro/a5200/archive/40c6f2f1ad4a3145b328d5baaf010fae6c7e752b.tar.gz",
+                    "sha256": "1b1c382028a188f58f3e1cb7e0f62c926c754824659612703647ce81b9fd4d9e"
                 }
             ]
         }

--- a/addons/game.libretro.atari800/game.libretro.atari800.json
+++ b/addons/game.libretro.atari800/game.libretro.atari800.json
@@ -34,9 +34,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/libretro/libretro-atari800",
-                    "commit": "9d3bcf283502512052e21c6f1453fbdf7aa3122b"
+                    "type": "archive",
+                    "url": "https://github.com/libretro/libretro-atari800/archive/9d3bcf283502512052e21c6f1453fbdf7aa3122b.tar.gz",
+                    "sha256": "7a32de824c4273d3c1edffe8116a7a60b84cb1a9f4b819df7a558bbadb2424ca"
                 }
             ]
         }

--- a/addons/game.libretro.beetle-bsnes/game.libretro.beetle-bsnes.json
+++ b/addons/game.libretro.beetle-bsnes/game.libretro.beetle-bsnes.json
@@ -34,9 +34,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/libretro/beetle-bsnes-libretro",
-                    "commit": "08e5a8cc719859180891544517816093f4dbd40a"
+                    "type": "archive",
+                    "url": "https://github.com/libretro/beetle-bsnes-libretro/archive/08e5a8cc719859180891544517816093f4dbd40a.tar.gz",
+                    "sha256": "6d6d1506a7358ff643aa90491fbae645b9e64244bcaaf2cb3851bfa0f14cc068"
                 },
                 {
                     "type": "file",

--- a/addons/game.libretro.beetle-bsnes/game.libretro.beetle-bsnes.json
+++ b/addons/game.libretro.beetle-bsnes/game.libretro.beetle-bsnes.json
@@ -40,7 +40,7 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/kodi-game/game.libretro.beetle-bsnes/6262d02f5698cccd48a57d3af905b30b6d850a38/depends/common/beetle-bsnes/0001-Fix-strlcpy-strlcat-fallback-with-glibc-2.38.patch",
+                    "url": "https://raw.githubusercontent.com/kodi-game/game.libretro.beetle-bsnes/016f1107b98fb946040258504106f0019a977a4c/depends/common/beetle-bsnes/0001-Fix-strlcpy-strlcat-fallback-with-glibc-2.38.patch",
                     "sha256": "f5027b984ec7ed4d292a16406c862f32244c6ccd88688d087f8cf3745f1e9526",
                     "dest-filename": "0001-Fix-strlcpy-strlcat-fallback-with-glibc-2.38.patch"
                 },

--- a/addons/game.libretro.beetle-gba/game.libretro.beetle-gba.json
+++ b/addons/game.libretro.beetle-gba/game.libretro.beetle-gba.json
@@ -34,9 +34,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/libretro/beetle-gba-libretro",
-                    "commit": "145d4884ad246e3c16765f6d69decb2a4359b6ae"
+                    "type": "archive",
+                    "url": "https://github.com/libretro/beetle-gba-libretro/archive/145d4884ad246e3c16765f6d69decb2a4359b6ae.tar.gz",
+                    "sha256": "140f19f3509c897405c4b1aeb0feac25138d0792241ec72c46ee373f77f2d10d"
                 }
             ]
         }

--- a/addons/game.libretro.beetle-lynx/game.libretro.beetle-lynx.json
+++ b/addons/game.libretro.beetle-lynx/game.libretro.beetle-lynx.json
@@ -34,9 +34,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/libretro/beetle-lynx-libretro",
-                    "commit": "fcdefcfb3c11d6d2e71be076a5d3df2e88ab73ed"
+                    "type": "archive",
+                    "url": "https://github.com/libretro/beetle-lynx-libretro/archive/fcdefcfb3c11d6d2e71be076a5d3df2e88ab73ed.tar.gz",
+                    "sha256": "3dd45a6f6585c444a415cb097996c572467754748e7163eca466d89b31bd8b37"
                 }
             ]
         }

--- a/addons/game.libretro.beetle-ngp/game.libretro.beetle-ngp.json
+++ b/addons/game.libretro.beetle-ngp/game.libretro.beetle-ngp.json
@@ -34,9 +34,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/libretro/beetle-ngp-libretro",
-                    "commit": "a50d5ac288a81f2104ddf43195a4efdd15c72227"
+                    "type": "archive",
+                    "url": "https://github.com/libretro/beetle-ngp-libretro/archive/a50d5ac288a81f2104ddf43195a4efdd15c72227.tar.gz",
+                    "sha256": "ffeabf2a357548f3a55423d542c31bb1e08571d81d7104f8213df3bfa2eb9c9f"
                 }
             ]
         }

--- a/addons/game.libretro.beetle-pce/game.libretro.beetle-pce.json
+++ b/addons/game.libretro.beetle-pce/game.libretro.beetle-pce.json
@@ -34,9 +34,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/libretro/beetle-pce-libretro",
-                    "commit": "ae99235c2139c176c1a8d0fde2957bf701d3cab0"
+                    "type": "archive",
+                    "url": "https://github.com/libretro/beetle-pce-libretro/archive/ae99235c2139c176c1a8d0fde2957bf701d3cab0.tar.gz",
+                    "sha256": "2af1581ddf1a23e80fee1238707b90f605dab2e2597041069b9600ea28f83f51"
                 }
             ]
         }

--- a/addons/game.libretro.beetle-pcfx/game.libretro.beetle-pcfx.json
+++ b/addons/game.libretro.beetle-pcfx/game.libretro.beetle-pcfx.json
@@ -46,9 +46,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/libretro/beetle-pcfx-libretro",
-                    "commit": "650c30ea2203636a1716675854d11c608ed6eacc"
+                    "type": "archive",
+                    "url": "https://github.com/libretro/beetle-pcfx-libretro/archive/650c30ea2203636a1716675854d11c608ed6eacc.tar.gz",
+                    "sha256": "29e9cc8beed9936c9b5524abf5e289799ba302761107a48e934a5f9d44235236"
                 }
             ]
         }

--- a/addons/game.libretro.beetle-psx/game.libretro.beetle-psx.json
+++ b/addons/game.libretro.beetle-psx/game.libretro.beetle-psx.json
@@ -34,9 +34,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/libretro/beetle-psx-libretro",
-                    "commit": "ed640fac8986d7813e4db6604544a6aafddd3018"
+                    "type": "archive",
+                    "url": "https://github.com/libretro/beetle-psx-libretro/archive/c699953afa01bc3f179edbcb14c4cfbeee6107a2.tar.gz",
+                    "sha256": "b9562ba7e71119bebd201452db9d7b839bc00a9f6cd3124066a2c4c784826b3c"
                 }
             ]
         }

--- a/addons/game.libretro.beetle-saturn/game.libretro.beetle-saturn.json
+++ b/addons/game.libretro.beetle-saturn/game.libretro.beetle-saturn.json
@@ -34,9 +34,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/libretro/beetle-saturn-libretro",
-                    "commit": "84461434f249c1b5cd10c83ae922feae84e1acf8"
+                    "type": "archive",
+                    "url": "https://github.com/libretro/beetle-saturn-libretro/archive/84461434f249c1b5cd10c83ae922feae84e1acf8.tar.gz",
+                    "sha256": "8d7c0e57c4dd31ca1e6e9122e5b4a306abe289963918809a16872a3a3b72d750"
                 }
             ]
         }

--- a/addons/game.libretro.beetle-supergrafx/game.libretro.beetle-supergrafx.json
+++ b/addons/game.libretro.beetle-supergrafx/game.libretro.beetle-supergrafx.json
@@ -34,9 +34,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/libretro/beetle-supergrafx-libretro",
-                    "commit": "3c6fcd3deded54ebecd69408f108407ac03d11b5"
+                    "type": "archive",
+                    "url": "https://github.com/libretro/beetle-supergrafx-libretro/archive/3c6fcd3deded54ebecd69408f108407ac03d11b5.tar.gz",
+                    "sha256": "87c5355089ad3d60befd76c2227062e48d6db5a33ab46e4b3efd680cb55a9ee9"
                 }
             ]
         }

--- a/addons/game.libretro.beetle-vb/game.libretro.beetle-vb.json
+++ b/addons/game.libretro.beetle-vb/game.libretro.beetle-vb.json
@@ -34,9 +34,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/libretro/beetle-vb-libretro",
-                    "commit": "3f53a40bf8aa18777514fd4b220960427e312a3f"
+                    "type": "archive",
+                    "url": "https://github.com/libretro/beetle-vb-libretro/archive/3f53a40bf8aa18777514fd4b220960427e312a3f.tar.gz",
+                    "sha256": "141f9b7a869c5632c2a59ca417f6d04b79687fd1ff05a2b62ed406139f317719"
                 }
             ]
         }

--- a/addons/game.libretro.beetle-wswan/game.libretro.beetle-wswan.json
+++ b/addons/game.libretro.beetle-wswan/game.libretro.beetle-wswan.json
@@ -34,9 +34,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/libretro/beetle-wswan-libretro",
-                    "commit": "4b01295838ea89e3f1355bbe4cb5cf98aa6108cd"
+                    "type": "archive",
+                    "url": "https://github.com/libretro/beetle-wswan-libretro/archive/4b01295838ea89e3f1355bbe4cb5cf98aa6108cd.tar.gz",
+                    "sha256": "bce15c0e2505e15b7b55fa1d51b4a12219d07a67be62bbca5c26678d0d89c659"
                 }
             ]
         }

--- a/addons/game.libretro.blastem/game.libretro.blastem.json
+++ b/addons/game.libretro.blastem/game.libretro.blastem.json
@@ -38,8 +38,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/libretro/blastem/archive/277e4a62668597d4f59cadda1cbafb844f981d45.tar.gz",
-                    "sha256": "1ad8eab6f528612d52f8310237d3e62a501e7449682369baa9eb5d4c73a6b90e"
+                    "url": "https://github.com/libretro/blastem/archive/84e567e17b6fb3cea23146c4209c18d50d46cbf0.tar.gz",
+                    "sha256": "7bf9a28959fbced50479e59b7832bf9b2a9746bb06620bdd5c28c89d205e8fc7"
                 }
             ]
         }

--- a/addons/game.libretro.bluemsx/game.libretro.bluemsx.json
+++ b/addons/game.libretro.bluemsx/game.libretro.bluemsx.json
@@ -34,9 +34,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/libretro/blueMSX-libretro",
-                    "commit": "0f32f52c48d3e772bfdf0379756f81f00b4e08bc"
+                    "type": "archive",
+                    "url": "https://github.com/libretro/blueMSX-libretro/archive/0f32f52c48d3e772bfdf0379756f81f00b4e08bc.tar.gz",
+                    "sha256": "708565144f365e45100b59a67e4f44782ccc74ab0a3db342f754b1e56e038252"
                 }
             ]
         }

--- a/addons/game.libretro.dosbox-pure/game.libretro.dosbox-pure.json
+++ b/addons/game.libretro.dosbox-pure/game.libretro.dosbox-pure.json
@@ -34,9 +34,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/libretro/dosbox-pure",
-                    "commit": "a4a0bab7f8931433588f2fcad9045c85b277373d"
+                    "type": "archive",
+                    "url": "https://github.com/libretro/dosbox-pure/archive/a4a0bab7f8931433588f2fcad9045c85b277373d.tar.gz",
+                    "sha256": "f0d04f087bb1c63a4cf1d46e314a9e0336afad427ddebbefde3daffe64b9005b"
                 }
             ]
         }

--- a/addons/game.libretro.dosbox/game.libretro.dosbox.json
+++ b/addons/game.libretro.dosbox/game.libretro.dosbox.json
@@ -34,9 +34,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/libretro/dosbox-libretro",
-                    "commit": "4024bf0048c261db58ef98cb5e16de291c429f4e"
+                    "type": "archive",
+                    "url": "https://github.com/libretro/dosbox-libretro/archive/4024bf0048c261db58ef98cb5e16de291c429f4e.tar.gz",
+                    "sha256": "49582f2c3a3abcf32819d25ec428d6350e15742e4642c9da8cdac7b8a76e8d79"
                 }
             ]
         }

--- a/addons/game.libretro.fceumm/game.libretro.fceumm.json
+++ b/addons/game.libretro.fceumm/game.libretro.fceumm.json
@@ -34,9 +34,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/libretro/libretro-fceumm",
-                    "commit": "b5e3566515c27dc66c9c20572171673126532e06"
+                    "type": "archive",
+                    "url": "https://github.com/libretro/libretro-fceumm/archive/b5e3566515c27dc66c9c20572171673126532e06.tar.gz",
+                    "sha256": "1ef34c9ed324f91856d6eca7d923e4f0d33ce85acb4b6a9b62d4a56c46e5ddc1"
                 }
             ]
         }

--- a/addons/game.libretro.gambatte/game.libretro.gambatte.json
+++ b/addons/game.libretro.gambatte/game.libretro.gambatte.json
@@ -34,9 +34,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/libretro/gambatte-libretro",
-                    "commit": "96174369b3c30d9fc57c926fa3379c273dc6a9a5"
+                    "type": "archive",
+                    "url": "https://github.com/libretro/gambatte-libretro/archive/96174369b3c30d9fc57c926fa3379c273dc6a9a5.tar.gz",
+                    "sha256": "3da5df4d2c2bb1f56a4990c613d68300c0f311f5b29d146f79dc6ae3b2529380"
                 }
             ]
         }

--- a/addons/game.libretro.gw/game.libretro.gw.json
+++ b/addons/game.libretro.gw/game.libretro.gw.json
@@ -34,9 +34,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/libretro/gw-libretro",
-                    "commit": "91d599b951e7bfe7e040347f58667cba20074adc"
+                    "type": "archive",
+                    "url": "https://github.com/libretro/gw-libretro/archive/91d599b951e7bfe7e040347f58667cba20074adc.tar.gz",
+                    "sha256": "88f47e3fe2ce7a5cdf42a087386a6cff5379dd2fe7901761c80a9f8d0d2185ad"
                 }
             ]
         }

--- a/addons/game.libretro.handy/game.libretro.handy.json
+++ b/addons/game.libretro.handy/game.libretro.handy.json
@@ -34,9 +34,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/libretro/libretro-handy",
-                    "commit": "bc55d462f0b2d6b073ea93dc552ebd73cec60fd1"
+                    "type": "archive",
+                    "url": "https://github.com/libretro/libretro-handy/archive/bc55d462f0b2d6b073ea93dc552ebd73cec60fd1.tar.gz",
+                    "sha256": "65ad333df22aab7f3c8156c21ffd0b8da1ef09c7a7f1775df964b89986aa7324"
                 }
             ]
         }

--- a/addons/game.libretro.mesen-s/game.libretro.mesen-s.json
+++ b/addons/game.libretro.mesen-s/game.libretro.mesen-s.json
@@ -34,9 +34,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/libretro/mesen-s",
-                    "commit": "1d475abd174d16ecb1fb030961ff26076ab51ee6"
+                    "type": "archive",
+                    "url": "https://github.com/libretro/Mesen-S/archive/1d475abd174d16ecb1fb030961ff26076ab51ee6.tar.gz",
+                    "sha256": "9dc6b2762769cae40ff2d008562fa0f8883d89906a693b44f1fbe8d8cfaedbd4"
                 }
             ]
         }

--- a/addons/game.libretro.mesen/game.libretro.mesen.json
+++ b/addons/game.libretro.mesen/game.libretro.mesen.json
@@ -34,9 +34,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/libretro/Mesen",
-                    "commit": "0102910c39ad1a62bc3f784466f3f67ca9eae335"
+                    "type": "archive",
+                    "url": "https://github.com/libretro/Mesen/archive/0102910c39ad1a62bc3f784466f3f67ca9eae335.tar.gz",
+                    "sha256": "360f97e907ada9b8e28a95652aa1d07656340e1d84ff868312745a566b250e01"
                 }
             ]
         }

--- a/addons/game.libretro.mrboom/game.libretro.mrboom.json
+++ b/addons/game.libretro.mrboom/game.libretro.mrboom.json
@@ -46,9 +46,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/kodi-game/mrboom-libretro",
-                    "commit": "89997083b6f492b5adbae3124a5ed2c784ace6eb"
+                    "type": "archive",
+                    "url": "https://github.com/kodi-game/mrboom-libretro/archive/89997083b6f492b5adbae3124a5ed2c784ace6eb.tar.gz",
+                    "sha256": "fa84d590cdefa54a892ecba71781f4c0ec091a51fb42525852a23ff3e85c1105"
                 }
             ]
         }

--- a/addons/game.libretro.mupen64plus-nx/game.libretro.mupen64plus-nx.json
+++ b/addons/game.libretro.mupen64plus-nx/game.libretro.mupen64plus-nx.json
@@ -35,8 +35,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/libretro/mupen64plus-libretro-nx/archive/8cdfadf266a784cd1849f7fef8adae2912240b18.tar.gz",
-                    "sha256": "d139af1f96142fa65e4dd614238e211bdafd974733153dae6d2a182d5a3e2e1c"
+                    "url": "https://github.com/kodi-game/mupen64plus-libretro-nx/archive/eb014557b9c26d798f138f7751c3d9c01a604573.tar.gz",
+                    "sha256": "9fb15f117da3bcce8cc8fc6c73b66044517a6cd3f862a36b7710939aa0af41bc"
                 }
             ]
         }

--- a/addons/game.libretro.nestopia/game.libretro.nestopia.json
+++ b/addons/game.libretro.nestopia/game.libretro.nestopia.json
@@ -34,9 +34,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/libretro/nestopia-libretro",
-                    "commit": "d0f461cee801c509748606e91c8ff0563ef62cd6"
+                    "type": "archive",
+                    "url": "https://github.com/libretro/nestopia/archive/d0f461cee801c509748606e91c8ff0563ef62cd6.tar.gz",
+                    "sha256": "b8273095754382ead61f7f9b41bc45e14886080462fce3dee004b2a796dd0741"
                 }
             ]
         }

--- a/addons/game.libretro.pcsx-rearmed/game.libretro.pcsx-rearmed.json
+++ b/addons/game.libretro.pcsx-rearmed/game.libretro.pcsx-rearmed.json
@@ -46,9 +46,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/libretro/pcsx_rearmed",
-                    "commit": "da2cb8ecd17fd0932ab6d94774c0522beebce6e3"
+                    "type": "archive",
+                    "url": "https://github.com/libretro/pcsx_rearmed/archive/da2cb8ecd17fd0932ab6d94774c0522beebce6e3.tar.gz",
+                    "sha256": "ff191a349aa88b7156f2c40ae32b7144884eec921542f07508d88715105d175e"
                 }
             ]
         }

--- a/addons/game.libretro.pokemini/game.libretro.pokemini.json
+++ b/addons/game.libretro.pokemini/game.libretro.pokemini.json
@@ -34,9 +34,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/libretro/pokemini",
-                    "commit": "132111b76343559860532a1ccc094f93f1ed5650"
+                    "type": "archive",
+                    "url": "https://github.com/libretro/PokeMini/archive/132111b76343559860532a1ccc094f93f1ed5650.tar.gz",
+                    "sha256": "53d1266404a823d1cf11b66b0d837c34604fa1623576275e52ec796b663ca2cf"
                 }
             ]
         }

--- a/addons/game.libretro.prboom/game.libretro.prboom.json
+++ b/addons/game.libretro.prboom/game.libretro.prboom.json
@@ -35,9 +35,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/libretro/libretro-prboom",
-                    "commit": "b4046cef3641d6bb28c0394915bfcc732cc49652"
+                    "type": "archive",
+                    "url": "https://github.com/libretro/libretro-prboom/archive/b4046cef3641d6bb28c0394915bfcc732cc49652.tar.gz",
+                    "sha256": "80f42cfbdc82e9a4197a1903f80ae41ba6aa3a27e343f362ed1b6c2c96c01510"
                 }
             ]
         }

--- a/addons/game.libretro.prosystem/game.libretro.prosystem.json
+++ b/addons/game.libretro.prosystem/game.libretro.prosystem.json
@@ -34,9 +34,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/libretro/prosystem-libretro",
-                    "commit": "363b6dfbd3e240762e022c2b4897b4fe55722be3"
+                    "type": "archive",
+                    "url": "https://github.com/libretro/prosystem-libretro/archive/363b6dfbd3e240762e022c2b4897b4fe55722be3.tar.gz",
+                    "sha256": "7abed225b58d306bd3988c6950f851aa52a4c7b30d97cedcf626aa18fbf05282"
                 }
             ]
         }

--- a/addons/game.libretro.quicknes/game.libretro.quicknes.json
+++ b/addons/game.libretro.quicknes/game.libretro.quicknes.json
@@ -34,9 +34,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/libretro/QuickNES_Core",
-                    "commit": "26bb785c9deddb66a17717b21bb4e328f03ade32"
+                    "type": "archive",
+                    "url": "https://github.com/libretro/QuickNES_Core/archive/26bb785c9deddb66a17717b21bb4e328f03ade32.tar.gz",
+                    "sha256": "2e19edc678f1606c9eb4a6807bbc9d71caa519fd917c953d4082929ad56b7795"
                 }
             ]
         }

--- a/addons/game.libretro.sameboy/game.libretro.sameboy.json
+++ b/addons/game.libretro.sameboy/game.libretro.sameboy.json
@@ -35,8 +35,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/libretro/SameBoy/archive/06c184f0b186f161bcdfec50ebd604fe789ed04a.tar.gz",
-                    "sha256": "0afbed5dae436c9006836b1801ab53b7a8fa6e1fbc740950303b34bc54758765"
+                    "url": "https://github.com/libretro/SameBoy/archive/aa158a889a48b538a0302873704a34577c8eb67d.tar.gz",
+                    "sha256": "6d80783ac470c15b5be1060e619eda01079f00c1c42fdfbcc65527b7dcd8b5b7"
                 }
             ]
         }

--- a/addons/game.libretro.stella/game.libretro.stella.json
+++ b/addons/game.libretro.stella/game.libretro.stella.json
@@ -34,9 +34,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/stella-emu/stella",
-                    "commit": "3f819a0d5760c3113610d1d07deb4ce9ea187517"
+                    "type": "archive",
+                    "url": "https://github.com/stella-emu/stella/archive/3f819a0d5760c3113610d1d07deb4ce9ea187517.tar.gz",
+                    "sha256": "adc133cab0231dcb674e9c9e771dbaa91e46275c4c8b6fbea676e43d5ac5612a"
                 }
             ]
         }

--- a/addons/game.libretro.supafaust/game.libretro.supafaust.json
+++ b/addons/game.libretro.supafaust/game.libretro.supafaust.json
@@ -34,9 +34,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/libretro/supafaust",
-                    "commit": "d6187e5337e6c2646d003db3ab1936727ca75301"
+                    "type": "archive",
+                    "url": "https://github.com/libretro/supafaust/archive/d6187e5337e6c2646d003db3ab1936727ca75301.tar.gz",
+                    "sha256": "239c78976ef98584e38b7b017d9c73e96c92397963b73d82cd8b941ae71a456d"
                 }
             ]
         }

--- a/addons/game.libretro.swanstation/game.libretro.swanstation.json
+++ b/addons/game.libretro.swanstation/game.libretro.swanstation.json
@@ -34,9 +34,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/libretro/swanstation",
-                    "commit": "5430a4a53b89fa5827c97b84ada29d23317245bc"
+                    "type": "archive",
+                    "url": "https://github.com/kodi-game/swanstation/archive/fc37fce91dedeba6e4007012cfed8de626fb45cf.tar.gz",
+                    "sha256": "d0b683021c079105c1f14be868390a6923614afdd36e6486a3b6b71b049922f4"
                 }
             ]
         }

--- a/addons/game.libretro.tgbdual/game.libretro.tgbdual.json
+++ b/addons/game.libretro.tgbdual/game.libretro.tgbdual.json
@@ -34,9 +34,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/libretro/tgbdual-libretro",
-                    "commit": "bf816b096f1dca55ea805337d7c9e78d6b98d839"
+                    "type": "archive",
+                    "url": "https://github.com/libretro/tgbdual-libretro/archive/bf816b096f1dca55ea805337d7c9e78d6b98d839.tar.gz",
+                    "sha256": "575d40a48a0b331ce82a683afd8c72f07d8880548c6db7ef5c25cba2bf4bc2da"
                 }
             ]
         }

--- a/addons/game.libretro.tyrquake/game.libretro.tyrquake.json
+++ b/addons/game.libretro.tyrquake/game.libretro.tyrquake.json
@@ -34,9 +34,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/libretro/tyrquake",
-                    "commit": "e57bb11597e8a00380f30f2627d219da960cf69a"
+                    "type": "archive",
+                    "url": "https://github.com/libretro/tyrquake/archive/e57bb11597e8a00380f30f2627d219da960cf69a.tar.gz",
+                    "sha256": "6bedb86899ad6da030d15e11fa4a1a6b61db77a56d658d8de650f63afd1e166c"
                 }
             ]
         }

--- a/addons/game.libretro.uae/game.libretro.uae.json
+++ b/addons/game.libretro.uae/game.libretro.uae.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.uae",
-            "commit": "2b9fbbb4cb2f7110a1a5b25e640213e6bfde42a3"
+            "commit": "04166ba2c1695cd09cda904712623e1248822b67"
         }
     ],
     "modules": [
@@ -36,9 +36,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/libretro/libretro-uae",
-                    "commit": "96ebfcfc2c66233ad37f6dc99ee991211dc719ad"
+                    "type": "archive",
+                    "url": "https://github.com/libretro/libretro-uae/archive/96ebfcfc2c66233ad37f6dc99ee991211dc719ad.tar.gz",
+                    "sha256": "af671aa1b42eb5b97a05b3ac2e57b6f397f3e17bbd0be7ac204636c2321d3cf0"
                 }
             ]
         }

--- a/addons/game.libretro.vbam/game.libretro.vbam.json
+++ b/addons/game.libretro.vbam/game.libretro.vbam.json
@@ -35,9 +35,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/visualboyadvance-m/visualboyadvance-m",
-                    "commit": "157eca385bc742ed26f0cbbd6adc9a9414a6f1ec"
+                    "type": "archive",
+                    "url": "https://github.com/visualboyadvance-m/visualboyadvance-m/archive/1bc817e16959b5cade42b1398ee0ff7582b5c402.tar.gz",
+                    "sha256": "d86242b570ce51be3c7dd9b3a7412ff82cb1e7927941f971bef0626ffe9dc7c8"
                 }
             ]
         }

--- a/addons/game.libretro.vbam/game.libretro.vbam.json
+++ b/addons/game.libretro.vbam/game.libretro.vbam.json
@@ -26,7 +26,7 @@
                 "cxxflags": "-g0"
             },
             "build-commands": [
-                "cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DENABLE_LIBRETRO=ON -DENABLE_WX=OFF -DENABLE_SDL=OFF -DENABLE_LINK=OFF -DBUILD_TESTING=OFF -DENABLE_LTO=OFF",
+                "cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DENABLE_LIBRETRO=ON -DENABLE_WX=OFF -DENABLE_LUA=OFF -DENABLE_SDL=OFF -DENABLE_LINK=OFF -DBUILD_TESTING=OFF -DENABLE_LTO=OFF",
                 "cmake --build build --target vbam_libretro -j$FLATPAK_BUILDER_N_JOBS",
                 "install -D -m 755 build/vbam_libretro.so /app/lib/libretro/vbam_libretro.so"
             ],

--- a/addons/game.libretro.virtualjaguar/game.libretro.virtualjaguar.json
+++ b/addons/game.libretro.virtualjaguar/game.libretro.virtualjaguar.json
@@ -34,9 +34,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/libretro/virtualjaguar-libretro",
-                    "commit": "59f7f9cc594ae6c6982c2bd8fc0dbf36873f9869"
+                    "type": "archive",
+                    "url": "https://github.com/libretro/virtualjaguar-libretro/archive/59f7f9cc594ae6c6982c2bd8fc0dbf36873f9869.tar.gz",
+                    "sha256": "81b2d166f1539d6278894965ed049b3267ad6260957bf25046eab2d98dd27c0b"
                 }
             ]
         }

--- a/addons/game.libretro.yabause/game.libretro.yabause.json
+++ b/addons/game.libretro.yabause/game.libretro.yabause.json
@@ -46,9 +46,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/libretro/yabause",
-                    "commit": "8926b0c6c347f8c5c755911ddb0ac695420ffbf8"
+                    "type": "archive",
+                    "url": "https://github.com/libretro/yabause/archive/8926b0c6c347f8c5c755911ddb0ac695420ffbf8.tar.gz",
+                    "sha256": "a76c92903d9aa0c53548127202760bf28568f16f169c5f26b09a507d1c08ddab"
                 }
             ]
         }

--- a/addons/game.libretro/game.libretro.json
+++ b/addons/game.libretro/game.libretro.json
@@ -38,7 +38,7 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/kodi-game/game.libretro/d04890600f5be1004056d42a936335de92d24b1f/depends/common/libretro-common/CMakeLists.txt",
+                    "url": "https://raw.githubusercontent.com/kodi-game/game.libretro/aa2d4b948f360167017bf331bfc349a10f314ec5/depends/common/libretro-common/CMakeLists.txt",
                     "sha256": "e45d4f77e57478ba27e6bcfcab2f7b641061cea24efd836e3d082e45cd0b688f"
                 }
             ]
@@ -65,7 +65,7 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/kodi-game/game.libretro/e01465001f4095cbab413f88a3769557e051d54f/depends/common/rcheevos/CMakeLists.txt",
+                    "url": "https://raw.githubusercontent.com/kodi-game/game.libretro/aa2d4b948f360167017bf331bfc349a10f314ec5/depends/common/rcheevos/CMakeLists.txt",
                     "sha256": "5a49ce4c200b2c9a6c2ce0e854c8c0530a7920e71e0eca5285962b0928f14563"
                 }
             ]

--- a/addons/game.libretro/game.libretro.json
+++ b/addons/game.libretro/game.libretro.json
@@ -33,8 +33,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/libretro/libretro-common/archive/a08b2b574787408abbb4ba34faf673117f9a0eae.tar.gz",
-                    "sha256": "448c6531e32783835fc900e1dffcf621ad2d0e29134f1e6645e2ee2a3132038f"
+                    "url": "https://github.com/libretro/libretro-common/archive/55ca668901e72eb885976c8c839e6903ecbb119d.tar.gz",
+                    "sha256": "f2bc6311bd1a62bf86207dbd6e6e78507350eedf411e4b31597e4a7555f022f1"
                 },
                 {
                     "type": "file",

--- a/addons/screensaver.stars/screensaver.stars.json
+++ b/addons/screensaver.stars/screensaver.stars.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/screensaver.stars",
-            "commit": "534dd4b9fe51107048e744f77e9aaa20d6bc528e"
+            "commit": "a30eee5143abdb957c95e9eb5e27dd9d9e4cc994"
         }
     ],
     "build-options": {

--- a/addons/screensavers.rsxs/screensavers.rsxs.json
+++ b/addons/screensavers.rsxs/screensavers.rsxs.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/screensavers.rsxs",
-            "commit": "704185a287c5c06a71306e94f280e45e476c4a36"
+            "commit": "0273a0ecbe1d908499da64db4cd39cafac333515"
         }
     ],
     "build-options": {

--- a/addons/visualization.projectm/visualization.projectm.json
+++ b/addons/visualization.projectm/visualization.projectm.json
@@ -58,10 +58,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/projectM-visualizer/projectm",
-                    "commit": "2f244141320f6b97b09bf99964cc72a4efdfcfd3",
-                    "disable-submodules": true
+                    "type": "archive",
+                    "url": "https://github.com/garbear/projectm/archive/e6bda8e744301f6395d4b4c8c5c77bfa9eae2598.tar.gz",
+                    "sha256": "8d0206a369f172c7a66eb4acf8291f21a8ac20124a88f2865dc126e211e83a61"
                 }
             ]
         }

--- a/tools/addon_updater.py
+++ b/tools/addon_updater.py
@@ -2,9 +2,11 @@
 
 import argparse
 import glob
+import hashlib
 import json
 import os.path
 import pprint
+import re
 import shutil
 import sys
 import tarfile
@@ -221,62 +223,90 @@ def _apply_git_update(source: dict, url: str, branch: str) -> bool:
     return True
 
 
-def _report_git_drift(source: dict, url: str, branch: str, addon_id: str) -> bool:
+def get_depends_pins(repo_name: str, ref: str) -> dict:
     """
-    Report, without writing, that url@branch has moved past the recorded
-    commit.  Used for module sources when --modules did not select them.
-    Returns True if drift was recorded.
+    Map dependency name -> (url, rev) parsed from every
+    depends/common/<name>/<name>.txt in the addon repo at ref.  rev is None
+    for archive urls, which embed their pin.
     """
-    if "x-checker-data" in source:
-        return False
-
-    commit = resolve_commit(url, branch)
-    current = source.get("commit", "")
-    if not commit or commit == current:
-        return False
-
-    state = "newer" if commit_is_newer(url, current, commit) else "not newer"
-    module_drift[f"{addon_id}: {url}"] = (
-        f"{current[:12]} → {commit[:12]} ({state}, resolved from '{branch}')"
-    )
-    return True
-
-
-def _walk_module_git_sources(module: dict, fallback_branch: str, action) -> int:
-    """
-    Recursively apply action(source, url, branch) to every github git source
-    within an inline module dict.  String entries (paths to external JSON
-    modules) are silently ignored.  Returns the number of sources the action
-    reported as handled.
-    """
-    if not isinstance(module, dict):
-        return 0
-    hits = 0
-    for source in module.get("sources", []):
-        if source.get("type") != "git":
-            continue
-        url = source.get("url", "")
-        if not url or not is_github_url(url):
-            continue
-        branch = source.get("branch", fallback_branch)
+    pins = {}
+    try:
+        repo = g.get_repo(repo_name)
+        entries = repo.get_contents("depends/common", ref=ref)
+    except Exception as e:
         if args.verbose:
-            print(f"  module '{module.get('name', '?')}' git source: {url}@{branch}")
-        if action(source, url, branch):
-            hits += 1
-    for sub in module.get("modules", []):
-        hits += _walk_module_git_sources(sub, fallback_branch, action)
-    return hits
+            print(f"  no depends/common in {repo_name}@{ref[:12]}: {e}")
+        return pins
+    for entry in entries:
+        if entry.type != "dir":
+            continue
+        path = f"depends/common/{entry.name}/{entry.name}.txt"
+        try:
+            raw = repo.get_contents(path, ref=ref).decoded_content.decode()
+        except Exception:
+            continue
+        parts = raw.split()
+        if len(parts) >= 2:
+            pins[parts[0]] = (parts[1], parts[2] if len(parts) > 2 else None)
+    return pins
 
 
-def modules_selected(addon_id: str) -> bool:
+def sha256_of_url(url: str) -> str | None:
+    digest = hashlib.sha256()
+    try:
+        with requests.get(url, stream=True, timeout=300) as response:
+            response.raise_for_status()
+            for chunk in response.iter_content(1 << 16):
+                digest.update(chunk)
+    except requests.RequestException as e:
+        print(f"  Warning: could not fetch {url}: {e}")
+        return None
+    return digest.hexdigest()
+
+
+def _align_module_source(module: dict, pins: dict, addon_id: str) -> None:
     """
-    True when --modules asked for addon_id's dependency modules to be bumped
-    to the latest githash.  Absent flag means no addon is selected, a bare
-    flag means every addon is.
+    Pin a module's first git/archive source to the addon's depends entry of
+    the same name (allowing a libretro- module name prefix).  Archive depends
+    become archive sources -- an upstream rebase cannot orphan those, unlike
+    a git commit pin -- and git depends keep a git source.  Sources managed
+    by flatpak-external-data-checker are left alone.
     """
-    if args.modules is None:
-        return False
-    return not args.modules or addon_id in args.modules
+    name = module.get("name", "")
+    key = name if name in pins else name.removeprefix("libretro-")
+    if key not in pins:
+        unmatched_modules.setdefault(addon_id, []).append(name)
+        return
+    url, rev = pins[key]
+    source = next(
+        (s for s in module.get("sources", []) if s.get("type") in ("git", "archive")),
+        None,
+    )
+    if source is None:
+        return
+    if "x-checker-data" in source:
+        if args.verbose:
+            print(f"  skipping {name}: managed by x-checker-data")
+        return
+    if get_addon_type(url) == "archive":
+        if source.get("url") == url and source.get("sha256"):
+            return
+        checksum = sha256_of_url(url)
+        if not checksum:
+            return
+        source.clear()
+        source.update({"type": "archive", "url": url, "sha256": checksum})
+    elif rev and re.fullmatch(r"[0-9a-f]{40}", rev):
+        if source.get("url") == url and source.get("commit") == rev:
+            return
+        source.clear()
+        source.update({"type": "git", "url": url, "commit": rev})
+    else:
+        print(f"  Warning: cannot align {name}: unsupported depends pin {url} {rev}")
+        return
+    aligned_modules.setdefault(addon_id, []).append(f"{name} -> {url}")
+    if args.verbose:
+        print(f"  aligned {name} -> {url}")
 
 
 def update_addon_sources(
@@ -289,43 +319,39 @@ def update_addon_sources(
        addon_data["sources"].  URL and branch come from the binary addon repo
        definition (.txt file).
 
-    2. git sources inside module definitions, but only for addons selected
-       with --modules; for the rest any drift is merely reported.  Those
-       upstreams are volatile, so following their branch HEAD is opt-in.
+    2. inline module sources are pinned to whatever the addon's depends files
+       declare at the resolved addon commit, so each core is exactly the one
+       the addon expects rather than a branch HEAD.
     """
     sources = addon_data.get("sources", [])
 
     # primary addon source
-    primary_idx = next(
-        (i for i, s in enumerate(sources) if s.get("type") in ("git", "archive")),
+    primary = next(
+        (s for s in sources if s.get("type") in ("git", "archive")),
         None,
     )
-    if primary_idx is not None:
-        primary = sources[primary_idx]
-        if main_atype == "git":
-            if args.verbose:
-                print(f"  primary source: {main_url}@{main_rev}")
-            _apply_git_update(primary, main_url, main_rev)
+    if primary is not None and main_atype == "git":
+        if args.verbose:
+            print(f"  primary source: {main_url}@{main_rev}")
+        _apply_git_update(primary, main_url, main_rev)
 
-    # module definitions
-    selected = modules_selected(addon_id)
-    for module in addon_data.get("modules", []):
-        if isinstance(module, str):
-            if args.verbose:
-                print(f"  skipping external module reference: {module}")
-            continue
-        if selected:
-            n = _walk_module_git_sources(module, main_rev, _apply_git_update)
-            if args.verbose and n:
-                print(
-                    f"  updated {n} git source(s) in module '{module.get('name', '?')}'"
-                )
-        else:
-            _walk_module_git_sources(
-                module,
-                main_rev,
-                lambda s, u, b: _report_git_drift(s, u, b, addon_id),
-            )
+    # module definitions: align to the addon's depends pins
+    modules = [m for m in addon_data.get("modules", []) if isinstance(m, dict)]
+    if (
+        modules
+        and primary is not None
+        and primary.get("type") == "git"
+        and is_github_url(primary.get("url", ""))
+        and primary.get("commit")
+    ):
+        pins = get_depends_pins(
+            _repo_name_from_url(primary["url"]), primary["commit"]
+        )
+        for module in modules:
+            _align_module_source(module, pins, addon_id)
+            for sub in module.get("modules", []):
+                if isinstance(sub, dict):
+                    _align_module_source(sub, pins, addon_id)
 
     return addon_data
 
@@ -345,15 +371,6 @@ parser.add_argument(
 )
 parser.add_argument(
     "-r", "--release", help="enable release builds", action="store_true"
-)
-parser.add_argument(
-    "-m",
-    "--modules",
-    nargs="*",
-    metavar="ADDON_ID",
-    help="also update the git sources of addon dependency modules to the "
-    "latest githash; no argument covers every addon, otherwise name the "
-    "addon ids to bump. Without this flag such drift is only reported.",
 )
 args = parser.parse_args()
 
@@ -381,7 +398,8 @@ skipped_addons = dict()
 missing_addons = list()
 updated_addons = set()
 rejected_updates = dict()
-module_drift = dict()
+aligned_modules = dict()
+unmatched_modules = dict()
 
 for f in repo_file_list:
     definition_file = os.path.basename(f)
@@ -473,6 +491,10 @@ print("\nmissing addons:")
 pp.pprint(missing_addons)
 print("\nrejected updates (resolved commit not newer than recorded):")
 pp.pprint(rejected_updates)
-print("\nmodule sources left alone (bump with --modules):")
-for source, drift in sorted(module_drift.items()):
-    print(f"  {source}\n      {drift}")
+print("\nmodules aligned to addon depends pins:")
+for addon, mods in sorted(aligned_modules.items()):
+    for m in mods:
+        print(f"  {addon}: {m}")
+print("\nmodules with no depends counterpart (left alone):")
+for addon, mods in sorted(unmatched_modules.items()):
+    print(f"  {addon}: {', '.join(mods)}")

--- a/tools/addon_updater.py
+++ b/tools/addon_updater.py
@@ -309,6 +309,43 @@ def _align_module_source(module: dict, pins: dict, addon_id: str) -> None:
         print(f"  aligned {name} -> {url}")
 
 
+def _align_raw_file_sources(
+    module: dict, repo_name: str, commit: str, addon_id: str
+) -> None:
+    """
+    File sources fetched from raw.githubusercontent.com at a pinned commit of
+    the addon repo (depends CMakeLists, patches) follow the primary pin: the
+    embedded commit is rewritten to the resolved addon commit and the file is
+    re-hashed, so the companion files always come from the same tree as the
+    depends pins.  A file that no longer exists at the new commit keeps its
+    old pin, with a warning.
+    """
+    prefix = f"https://raw.githubusercontent.com/{repo_name}/"
+    pattern = re.compile(re.escape(prefix) + r"([0-9a-f]{40})/(.+)")
+    for source in module.get("sources", []):
+        if source.get("type") != "file":
+            continue
+        match = pattern.fullmatch(source.get("url", ""))
+        if not match or match.group(1) == commit:
+            continue
+        url = f"{prefix}{commit}/{match.group(2)}"
+        checksum = sha256_of_url(url)
+        if not checksum:
+            print(
+                f"  Warning: keeping {source['url']}: "
+                f"file unavailable at {commit[:12]}"
+            )
+            continue
+        source["url"] = url
+        source["sha256"] = checksum
+        source.pop("sha512", None)
+        aligned_modules.setdefault(addon_id, []).append(
+            f"{module.get('name', '?')} file {match.group(2)} -> @{commit[:12]}"
+        )
+        if args.verbose:
+            print(f"  aligned file {match.group(2)} -> {commit[:12]}")
+
+
 def update_addon_sources(
     addon_id: str, addon_data: dict, main_url: str, main_rev: str, main_atype: str
 ) -> dict:
@@ -344,14 +381,17 @@ def update_addon_sources(
         and is_github_url(primary.get("url", ""))
         and primary.get("commit")
     ):
-        pins = get_depends_pins(
-            _repo_name_from_url(primary["url"]), primary["commit"]
-        )
+        repo_name = _repo_name_from_url(primary["url"])
+        pins = get_depends_pins(repo_name, primary["commit"])
         for module in modules:
             _align_module_source(module, pins, addon_id)
+            _align_raw_file_sources(module, repo_name, primary["commit"], addon_id)
             for sub in module.get("modules", []):
                 if isinstance(sub, dict):
                     _align_module_source(sub, pins, addon_id)
+                    _align_raw_file_sources(
+                        sub, repo_name, primary["commit"], addon_id
+                    )
 
     return addon_data
 


### PR DESCRIPTION
Each kodi-game addon declares the exact core it builds against in its depends files. addon_updater.py now reads those and pins each core module to them, as archive sources with checksums, instead of chasing the core repo's branch HEAD. Companion files fetched from the addon repo (depends CMakeLists, patches) follow the addon pin too.

This also fixes a broken build: kodi-game/game.libretro deleted its master branch, so the commit beta currently pins no longer exists. game.libretro now pins the Piers branch head.

vbam needed Lua scripting disabled; it downloads sources at configure time, which cannot work in the offline build sandbox.

Everything build-tested locally on x86_64.