### PR TITLE
ffmpeg: add v4l2-request patches from LE and enable for aarch64

### DIFF
--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -121,6 +121,8 @@ modules:
         aarch64:
           config-opts:
             - --enable-v4l2_m2m
+            - --enable-v4l2-request
+            - --enable-libudev
     cleanup:
       - /bin
     sources:
@@ -138,6 +140,17 @@ modules:
       - type: shell
         commands:
           - patch -p1 < 001-ffmpeg-all-libpostproc-plugin.patch
+      - type: file
+        url: https://raw.githubusercontent.com/LibreELEC/LibreELEC.tv/e9e6b8531df13bc9058ca1771dab5f0c4fd5e98e/packages/multimedia/ffmpeg/patches/v4l2-request/0001-v4l2-request.patch
+        sha256: afd04c202c27081c355d8d34b58a52c4141de26433007e27ed6e0d2093d10d3c
+        dest-filename: 0001-v4l2-request.patch
+        only-arches:
+          - aarch64
+      - type: shell
+        only-arches:
+          - aarch64
+        commands:
+          - patch -p1 < 0001-v4l2-request.patch
   - name: flatbuffers
     buildsystem: cmake-ninja
     config-opts:


### PR DESCRIPTION
Second attempt at #707, now that LibreELEC carries the patch rebased onto vanilla ffmpeg 9.0.

Upstream ffmpeg (n9.0.1) still has no V4L2 Request API hwaccels, so `--enable-v4l2_m2m` alone enables nothing on SoCs whose mainline decoders are stateless (Rockchip, Allwinner, ...). This pulls LibreELEC's `0001-v4l2-request.patch`, pinned by commit SHA and sha256 using the same approach as the existing libpostproc patch, gated on aarch64, and configures ffmpeg with `--enable-v4l2-request --enable-libudev` (libudev comes from the SDK, already used via ENABLE_UDEV).

Verified the patch applies cleanly to n9.0.1 (zero failed hunks). Note it is a multi-commit squash touching `configure` twice, so `patch --dry-run`/`git apply --check` false-negative on it; a real sequential `patch -p1` applies fine.

LibreELEC's additional HEVC `sps_st_rps` patch for rkvdec2 is deliberately **not** included: it depends on kernel 6.20 uAPI (FROMGIT in the media tree) and sends the new control unconditionally, which would regress stateless HEVC on non-Rockchip SoCs in a generic build. To be revisited when the control handling grows a runtime probe. Practical effect: on RK3588 HEVC stays software-decoded for now, while H.264/MPEG-2/VP8/VP9/AV1 use the hardware decoders where the kernel exposes them.

Tested against an Orange Pi 5 Pro (RK3588S) running the Kodi flatpak with `--windowing=gbm` on kernel 6.18.
