### PR TITLE
vfs.sftp: fix libssh source 403; update libevdev

### DIFF
--- a/addons/vfs.sftp/vfs.sftp.json
+++ b/addons/vfs.sftp/vfs.sftp.json
@@ -26,13 +26,13 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://git.libssh.org/projects/libssh.git/snapshot/libssh-0.12.2.tar.gz",
-                    "sha256": "6d3c4025c746dd31571f1e241d4c15e4e23a4c45fc2b725fdec42b678d7205c5",
+                    "url": "https://www.libssh.org/files/0.12/libssh-0.12.2.tar.xz",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 1729,
-                        "url-template": "https://git.libssh.org/projects/libssh.git/snapshot/libssh-$version.tar.gz"
-                    }
+                        "url-template": "https://www.libssh.org/files/$major.$minor/libssh-$version.tar.xz"
+                    },
+                    "sha256": "49560f677d96e3706a904ac2de1116e25f3680937d51e5c92198fcba4a1c1e9f"
                 }
             ]
         }

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -346,8 +346,8 @@ modules:
           - -Ddocumentation=disabled
         sources:
           - type: archive
-            url: https://www.freedesktop.org/software/libevdev/libevdev-1.13.6.tar.xz
-            sha256: 73f215eccbd8233f414737ac06bca2687e67c44b97d2d7576091aa9718551110
+            url: https://www.freedesktop.org/software/libevdev/libevdev-1.13.7.tar.xz
+            sha256: 0caf824971108f15bb2ad356433bae198d7d3bf1e82d43f63626e069e060bfa6
             x-checker-data:
               type: anitya
               project-id: 20540


### PR DESCRIPTION
The cgit snapshot endpoint on git.libssh.org answers 403 to flathub CI, killing every source download. Fetch libssh from its official release tarball on www.libssh.org instead (same 0.12.2 version, cherry-picked from beta).

Also carries the pending external-data-checker update: libevdev 1.13.6 -> 1.13.7.

Closes #778, which fails CI on the libssh 403.