### PR TITLE
beta: transition to 26.08 SDK

### DIFF
--- a/addons/game.libretro.beetle-ngp/game.libretro.beetle-ngp.json
+++ b/addons/game.libretro.beetle-ngp/game.libretro.beetle-ngp.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.beetle-ngp",
-            "commit": "7a10921d82bbb77e39c5812de0f1c67730608215"
+            "commit": "60d8264646e0ce4f4157ba92392823f1b460442a"
         }
     ],
     "modules": [

--- a/addons/game.libretro.beetle-psx/game.libretro.beetle-psx.json
+++ b/addons/game.libretro.beetle-psx/game.libretro.beetle-psx.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.beetle-psx",
-            "commit": "e012d75b9d381814646b9fd8550277e49fee73d1"
+            "commit": "4f243867f69d9975968cd3d9df79d2fc151e2aee"
         }
     ],
     "modules": [
@@ -35,8 +35,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/kodi-game/beetle-psx-libretro/archive/21c4802caad3d9634f39be433ae4e085b0c1f7be.tar.gz",
-                    "sha256": "66d5b969b1b1dd81eaf2fc7b05adbc30cd12cbfda3cbe0dc278969f70eb8bdaa"
+                    "url": "https://github.com/kodi-game/beetle-psx-libretro/archive/dbd9abe2801ea246d8cec2a5aefc9fd8b224bc8a.tar.gz",
+                    "sha256": "63d303cdddf5a1279559abeeed67f015cfa991f34ead923b34a29b2fbf1ae1a3"
                 }
             ]
         }

--- a/addons/game.libretro.dosbox-pure/game.libretro.dosbox-pure.json
+++ b/addons/game.libretro.dosbox-pure/game.libretro.dosbox-pure.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.dosbox-pure",
-            "commit": "b6d9b6f71739fb289ddbcd7cc0fae363b1ac9272"
+            "commit": "2aefa1087ab2a39575daf8dde85d0e69da1f60d4"
         }
     ],
     "modules": [

--- a/addons/game.libretro.melonds/game.libretro.melonds.json
+++ b/addons/game.libretro.melonds/game.libretro.melonds.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.melonds",
-            "commit": "e25b66e338d0d26c84304ca25f32534574487930"
+            "commit": "5c2e91b38f0f820e418bd7e1c01e1c7bc660c2d2"
         }
     ],
     "modules": [

--- a/addons/game.libretro.o2em/game.libretro.o2em.json
+++ b/addons/game.libretro.o2em/game.libretro.o2em.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.o2em",
-            "commit": "cd1d937cce30abb46d0d690714e180d3f80ad792"
+            "commit": "7bf08699e3ddfa60a6a5999fbd358dea4f12de8d"
         }
     ],
     "modules": [

--- a/addons/game.libretro.pcsx-rearmed/game.libretro.pcsx-rearmed.json
+++ b/addons/game.libretro.pcsx-rearmed/game.libretro.pcsx-rearmed.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.pcsx-rearmed",
-            "commit": "7caa950ed2d530fefc50db7f8af147b22b5be84c"
+            "commit": "60387e31f341c92e40cb63ba666d3bae01168afa"
         }
     ],
     "modules": [
@@ -47,8 +47,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/libretro/pcsx_rearmed/archive/da2cb8ecd17fd0932ab6d94774c0522beebce6e3.tar.gz",
-                    "sha256": "ff191a349aa88b7156f2c40ae32b7144884eec921542f07508d88715105d175e"
+                    "url": "https://github.com/libretro/pcsx_rearmed/archive/8625c395a24411f8c77e69802b516df9c613a712.tar.gz",
+                    "sha256": "e0bb6f9e4e0131458ced5049c3eec4fbe1ba2703e1e4be7f98079cf643bfef4a"
                 }
             ]
         }

--- a/addons/game.libretro.swanstation/game.libretro.swanstation.json
+++ b/addons/game.libretro.swanstation/game.libretro.swanstation.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.swanstation",
-            "commit": "a1b3b72bdc23742266fde14019e360bbada488ea"
+            "commit": "a325083bc0c26b11c54a8674289c676b85f8f75b"
         }
     ],
     "modules": [
@@ -35,8 +35,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/kodi-game/swanstation/archive/fc37fce91dedeba6e4007012cfed8de626fb45cf.tar.gz",
-                    "sha256": "d0b683021c079105c1f14be868390a6923614afdd36e6486a3b6b71b049922f4"
+                    "url": "https://github.com/libretro/swanstation/archive/7f69c199ed88d5723f71dd3a6e9c1b7a45b535a6.tar.gz",
+                    "sha256": "d3a9e60a8b338f3edcfd8caeff54bbecc797668f0cda9e85f703255f69c5a821"
                 }
             ]
         }

--- a/addons/game.libretro.tyrquake/game.libretro.tyrquake.json
+++ b/addons/game.libretro.tyrquake/game.libretro.tyrquake.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.tyrquake",
-            "commit": "fd25c871ca18dbaa04c357aa4a4974b7ad65928d"
+            "commit": "d554c4fc784895621edeb711b961c9798438b966"
         }
     ],
     "modules": [

--- a/addons/game.libretro.yabause/game.libretro.yabause.json
+++ b/addons/game.libretro.yabause/game.libretro.yabause.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.yabause",
-            "commit": "3043ce9aba588dde80e0aa1289dd6d92c4ac37e9"
+            "commit": "5c5ce1bdf906d39cef7a39161b34400c697e076f"
         }
     ],
     "modules": [

--- a/addons/game.shader.presets/game.shader.presets.json
+++ b/addons/game.shader.presets/game.shader.presets.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.shader.presets",
-            "commit": "18117d71e03338f1ad9a623655800ef51f52dcc0"
+            "commit": "a4c240f8c3a340bdd2d3f64894de386930ea579b"
         }
     ]
 }

--- a/addons/imagedecoder.heif/imagedecoder.heif.json
+++ b/addons/imagedecoder.heif/imagedecoder.heif.json
@@ -5,68 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/imagedecoder.heif",
-            "commit": "fa0d45fb6caf6ad6187d2cdf370e0184a7918836"
-        }
-    ],
-    "modules": [
-        {
-            "name": "libde265",
-            "buildsystem": "cmake-ninja",
-            "cleanup": [
-                "/bin"
-            ],
-            "build-options": {
-                "no-debuginfo": true,
-                "cflags": "-g0",
-                "cxxflags": "-g0"
-            },
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://github.com/strukturag/libde265/archive/v1.1.1/libde265-1.1.1.tar.gz",
-                    "sha256": "5b4fac677018e6074196e8f9889f3e4a5310e46afbf22a893f620d4e24d3510e",
-                    "x-checker-data": {
-                        "type": "json",
-                        "url": "https://api.github.com/repos/strukturag/libde265/releases/latest",
-                        "tag-query": ".tag_name",
-                        "timestamp-query": ".published_at",
-                        "version-query": "$tag | sub(\"^[vV]\"; \"\")",
-                        "url-query": "\"https://github.com/strukturag/libde265/archive/\\($tag)/libde265-\\($version).tar.gz\""
-                    }
-                }
-            ]
-        },
-        {
-            "name": "libheif",
-            "buildsystem": "cmake-ninja",
-            "config-opts": [
-                "-DCMAKE_BUILD_TYPE=Release",
-                "-DWITH_EXAMPLES=OFF",
-                "-DWITH_AOM_DECODER=OFF",
-                "-DWITH_AOM_ENCODER=OFF",
-                "-DWITH_DAV1D=ON",
-                "-DENABLE_PLUGIN_LOADING=OFF"
-            ],
-            "build-options": {
-                "no-debuginfo": true,
-                "cflags": "-g0",
-                "cxxflags": "-g0"
-            },
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://github.com/strukturag/libheif/archive/v1.23.2/libheif-1.23.2.tar.gz",
-                    "sha256": "1405ed070421459b569ff49deab109b7f1a30a447e72a9b20a4154f774634a44",
-                    "x-checker-data": {
-                        "type": "json",
-                        "url": "https://api.github.com/repos/strukturag/libheif/releases/latest",
-                        "tag-query": ".tag_name",
-                        "timestamp-query": ".published_at",
-                        "version-query": "$tag | sub(\"^[vV]\"; \"\")",
-                        "url-query": "\"https://github.com/strukturag/libheif/archive/\\($tag)/libheif-\\($version).tar.gz\""
-                    }
-                }
-            ]
+            "commit": "297b45011034c679c7439b52ca4187fb56739c85"
         }
     ],
     "build-options": {

--- a/addons/imagedecoder.svg/imagedecoder.svg.json
+++ b/addons/imagedecoder.svg/imagedecoder.svg.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/imagedecoder.svg",
-            "commit": "15aac0dbd088c17298865a38a73b66ebf508927c"
+            "commit": "cb50710f4d7ceb173c1608289b5dd49b003d9353"
         }
     ],
     "modules": [

--- a/addons/inputstream.airplay/inputstream.airplay.json
+++ b/addons/inputstream.airplay/inputstream.airplay.json
@@ -9,7 +9,7 @@
         {
             "type": "git",
             "url": "https://github.com/popcornmix/inputstream.airplay",
-            "commit": "5c1bdedc2176d4452f989c28a65c5d7d883d7e4f"
+            "commit": "18dfcae27b28cecd4a724a32b1b486449060f512"
         },
         {
             "type": "archive",

--- a/addons/inputstream.rtmp/inputstream.rtmp.json
+++ b/addons/inputstream.rtmp/inputstream.rtmp.json
@@ -28,6 +28,10 @@
                     "type": "archive",
                     "url": "https://github.com/mirror/rtmpdump/archive/6f6bb1353fc84f4cc37138baa99f586750028a01.tar.gz",
                     "sha256": "5d68d69710be21e86e766753d2bd25cb2ad1c853b0bc80ebe6b49a6cc507bfc0"
+                },
+                {
+                    "type": "patch",
+                    "path": "../../patches/rtmpdump-nettle4-digest.patch"
                 }
             ]
         }

--- a/addons/peripheral.joystick/peripheral.joystick.json
+++ b/addons/peripheral.joystick/peripheral.joystick.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/peripheral.joystick",
-            "commit": "a18a692ce0250e0fc80b9e386baa48385051aa23"
+            "commit": "2020033e404293f121fcd26633a32eca11a08e95"
         }
     ],
     "build-options": {

--- a/addons/pvr.argustv/pvr.argustv.json
+++ b/addons/pvr.argustv/pvr.argustv.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.argustv",
-            "commit": "0c922283d92de6327e91f0592c5e0aa020982db5"
+            "commit": "07f86b66f5e3bea3530fee0fe43757be8159fe27"
         }
     ],
     "build-options": {

--- a/addons/pvr.dvblink/pvr.dvblink.json
+++ b/addons/pvr.dvblink/pvr.dvblink.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.dvblink",
-            "commit": "47b9ede2fff1601a33be20148cca7eb88af6e0cb"
+            "commit": "eb2dfe3a56cf4baad95c3661139808d8a3a8b46e"
         }
     ],
     "build-options": {

--- a/addons/pvr.iptvsimple/pvr.iptvsimple.json
+++ b/addons/pvr.iptvsimple/pvr.iptvsimple.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.iptvsimple",
-            "commit": "78a023cb31c5b87df2cebe1d9c4ac2f000ba1c1a"
+            "commit": "7d30fc569584268199b915600557774edbfcd110"
         }
     ],
     "build-options": {

--- a/addons/pvr.mythtv/pvr.mythtv.json
+++ b/addons/pvr.mythtv/pvr.mythtv.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/janbar/pvr.mythtv",
-            "commit": "48995faf9764c99ce9db163740926e6ec458bc11"
+            "commit": "ffc12c7266092da23b15d71c9d98db7daa5724fd"
         }
     ],
     "build-options": {

--- a/addons/pvr.stalker/pvr.stalker.json
+++ b/addons/pvr.stalker/pvr.stalker.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.stalker",
-            "commit": "07989d2d8e5542135c5c7107ffeb4c316f7f65fc"
+            "commit": "ef9a5726feb3c9ecea5e695ea913712e90594af0"
         }
     ],
     "build-options": {

--- a/addons/pvr.vdr.vnsi/pvr.vdr.vnsi.json
+++ b/addons/pvr.vdr.vnsi/pvr.vdr.vnsi.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.vdr.vnsi",
-            "commit": "17d6f0f98cbd577d5a9c59f17ca70eaf70131c0e"
+            "commit": "767983f9e468ac840f8920d7ef522a29e5a1170e"
         }
     ],
     "build-options": {

--- a/addons/vfs.libarchive/vfs.libarchive.json
+++ b/addons/vfs.libarchive/vfs.libarchive.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/xbmc/vfs.libarchive",
-            "commit": "9fc2819a82697d1ac8f875aebb728e01ab2dc882"
+            "commit": "12c0d9f80e4f3d2bd0435a9b6ba2d5b539a474e5"
         }
     ],
     "build-options": {

--- a/patches/rtmpdump-nettle4-digest.patch
+++ b/patches/rtmpdump-nettle4-digest.patch
@@ -1,0 +1,73 @@
+Description: fix build against nettle >= 4.0
+ nettle 4.0 dropped the digest length argument from the *_digest
+ functions. Pick the matching macro form via NETTLE_VERSION_MAJOR so
+ both old and new nettle keep building.
+Author: Kel Modderman <kelvmod@gmail.com>
+Forwarded: yes
+Last-Update: 2026-09-03
+--- a/librtmp/handshake.h
++++ b/librtmp/handshake.h
+@@ -45,6 +45,7 @@
+ #elif defined(USE_GNUTLS)
+ #include <nettle/hmac.h>
+ #include <nettle/arcfour.h>
++#include <nettle/version.h>
+ #ifndef SHA256_DIGEST_LENGTH
+ #define SHA256_DIGEST_LENGTH	32
+ #endif
+@@ -52,7 +53,11 @@
+ #define HMAC_CTX	struct hmac_sha256_ctx
+ #define HMAC_setup(ctx, key, len)	hmac_sha256_set_key(&ctx, len, key)
+ #define HMAC_crunch(ctx, buf, len)	hmac_sha256_update(&ctx, len, buf)
++#if NETTLE_VERSION_MAJOR >= 4
++#define HMAC_finish(ctx, dig, dlen)	dlen = SHA256_DIGEST_LENGTH; hmac_sha256_digest(&ctx, dig)
++#else
+ #define HMAC_finish(ctx, dig, dlen)	dlen = SHA256_DIGEST_LENGTH; hmac_sha256_digest(&ctx, SHA256_DIGEST_LENGTH, dig)
++#endif
+ #define HMAC_close(ctx)
+ 
+ typedef struct arcfour_ctx*	RC4_handle;
+--- a/librtmp/hashswf.c
++++ b/librtmp/hashswf.c
+@@ -44,6 +44,7 @@
+ #define HMAC_close(ctx)
+ #elif defined(USE_GNUTLS)
+ #include <nettle/hmac.h>
++#include <nettle/version.h>
+ #ifndef SHA256_DIGEST_LENGTH
+ #define SHA256_DIGEST_LENGTH	32
+ #endif
+@@ -51,7 +52,11 @@
+ #define HMAC_CTX	struct hmac_sha256_ctx
+ #define HMAC_setup(ctx, key, len)	hmac_sha256_set_key(&ctx, len, key)
+ #define HMAC_crunch(ctx, buf, len)	hmac_sha256_update(&ctx, len, buf)
++#if NETTLE_VERSION_MAJOR >= 4
++#define HMAC_finish(ctx, dig, dlen)	dlen = SHA256_DIGEST_LENGTH; hmac_sha256_digest(&ctx, dig)
++#else
+ #define HMAC_finish(ctx, dig, dlen)	dlen = SHA256_DIGEST_LENGTH; hmac_sha256_digest(&ctx, SHA256_DIGEST_LENGTH, dig)
++#endif
+ #define HMAC_close(ctx)
+ #else	/* USE_OPENSSL */
+ #include <openssl/ssl.h>
+--- a/librtmp/rtmp.c
++++ b/librtmp/rtmp.c
+@@ -57,6 +57,7 @@
+ #define MD5_DIGEST_LENGTH 16
+ #include <nettle/base64.h>
+ #include <nettle/md5.h>
++#include <nettle/version.h>
+ #else	/* USE_OPENSSL */
+ #include <openssl/ssl.h>
+ #include <openssl/rc4.h>
+@@ -2492,7 +2493,11 @@
+ typedef struct md5_ctx	MD5_CTX;
+ #define MD5_Init(ctx)	md5_init(ctx)
+ #define MD5_Update(ctx,data,len)	md5_update(ctx,len,data)
++#if NETTLE_VERSION_MAJOR >= 4
++#define MD5_Final(dig,ctx)	md5_digest(ctx,dig)
++#else
+ #define MD5_Final(dig,ctx)	md5_digest(ctx,MD5_DIGEST_LENGTH,dig)
++#endif
+ #else
+ #endif
+ 

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -1,6 +1,6 @@
 app-id: tv.kodi.Kodi
 runtime: org.freedesktop.Platform
-runtime-version: '25.08'
+runtime-version: '26.08'
 sdk: org.freedesktop.Sdk
 command: kodi
 rename-icon: kodi

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -87,24 +87,6 @@ modules:
           project-id: 147
           url-template: https://github.com/avahi/avahi/archive/refs/tags/v$version.tar.gz
           stable-only: false
-  - name: dav1d
-    buildsystem: meson
-    config-opts:
-      - -Ddefault_library=shared
-      - -Denable_asm=true
-      - -Denable_tools=false
-      - -Denable_examples=false
-      - -Denable_tests=false
-    cleanup:
-      - /bin
-    sources:
-      - type: archive
-        url: https://code.videolan.org/videolan/dav1d/-/archive/1.5.4/dav1d-1.5.4.tar.bz2
-        sha512: 1e4dbc409ce77c61c5e4a4f8d6855c35cabf3da5dd6456beccb4c13d0fa58a50045d8ce5bb6832516fe860e6d27303b7b6b8404b330581e122513d39d524dbcc
-        x-checker-data:
-          type: anitya
-          project-id: 18920
-          url-template: https://code.videolan.org/videolan/dav1d/-/archive/$version/dav1d-$version.tar.bz2
   - name: ffmpeg
     config-opts:
       - --enable-shared

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -311,8 +311,8 @@ modules:
       - /bin
     sources:
       - type: archive
-        url: https://github.com/Pulse-Eight/libcec/archive/libcec-8.1.6.tar.gz
-        sha256: e1e762fee8589def3cbceb1f3e53ba06ed5b557a2705b86a225f8f30fb19c79a
+        url: https://github.com/Pulse-Eight/libcec/archive/libcec-8.1.7.tar.gz
+        sha256: e4ac4d1dd3559cf83189d29ab40fc5537b5a2beceb82916ef173dac7e50dbfa0
         x-checker-data:
           type: anitya
           project-id: 21468
@@ -404,8 +404,8 @@ modules:
       - /bin
     sources:
       - type: archive
-        url: https://github.com/sahlberg/libnfs/archive/libnfs-7.0.1.tar.gz
-        sha512: 59e26c1131370482b8da0eba54da54c6270a8c9f683bd7ad74a95ff06a7fc9fd744ff60c04bb3d44d6278acb6e57b3f7f0d4825e6e8f53c9e216dd000cd1c001
+        url: https://github.com/sahlberg/libnfs/archive/libnfs-7.0.2.tar.gz
+        sha512: 722d7a65090153a9892749fc7b9513d86a75534f7ea49ad4ce18c3360c3740b0c7255e4510fd956215eb25f807fbdc668c1af0262a4cc87de678561198448f8b
         x-checker-data:
           type: anitya
           project-id: 7325
@@ -447,8 +447,8 @@ modules:
       - /bin
     sources:
       - type: archive
-        url: https://github.com/mariadb-corporation/mariadb-connector-c/archive/refs/tags/v3.4.9.tar.gz
-        sha512: 950433b847316d02025889933e802bf295c3c136f57411c484a5e64a951ff23e4436e5dc55c7b643e625f5c79318a270451f9445ad9f17e027ca79c1cbbee8e2
+        url: https://github.com/mariadb-corporation/mariadb-connector-c/archive/refs/tags/v3.4.10.tar.gz
+        sha512: 8ab06eff88a0fdb278a6be566cb47e8a0828fb44b7b46c0ec35caab4c7b92ab2486ac6356537c07ed77b84d65d5f70dd703b87adf9b331fc96c72221cbbdd9cd
         x-checker-data:
           type: anitya
           project-id: 16939

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -224,18 +224,6 @@ modules:
           - echo 'install(FILES ${SIMD_HEADER} ${SIMD_INLINE} DESTINATION include/glm/simd)'
             >> glm/CMakeLists.txt
           - echo 'install(TARGETS glm)' >> glm/CMakeLists.txt
-  - name: hwdata
-    config-opts:
-      - --datarootdir=${FLATPAK_DEST}/lib/
-    sources:
-      - type: archive
-        url: https://github.com/vcrhonek/hwdata/archive/v0.410/hwdata-0.410.tar.gz
-        sha256: 2864b061b179b8ad8cb6a7339ca07678240a183d9cedce8677a4950acaf798e0
-        x-checker-data:
-          type: anitya
-          project-id: 5387
-          stable-only: true
-          url-template: https://github.com/vcrhonek/hwdata/archive/v$version/hwdata-$version.tar.gz
   - name: json
     buildsystem: cmake-ninja
     config-opts:

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -2,8 +2,6 @@ app-id: tv.kodi.Kodi
 runtime: org.freedesktop.Platform
 runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
-sdk-extensions:
-  - org.freedesktop.Sdk.Extension.openjdk17
 command: kodi
 rename-icon: kodi
 rename-desktop-file: kodi.desktop
@@ -141,9 +139,14 @@ modules:
         url: https://raw.githubusercontent.com/xbmc/xbmc/bc56c2fcd679a9bbb8c9d13b505a6c7285f7206c/tools/depends/target/ffmpeg/001-ffmpeg-all-libpostproc-plugin.patch
         sha256: 019ab331eac814e4995c65dcc8076cc433a64bb4a5d2aa6aef5516922dd691e6
         dest-filename: 001-ffmpeg-all-libpostproc-plugin.patch
+      - type: file
+        url: https://raw.githubusercontent.com/xbmc/xbmc/4719e45848e3aeda84f07247fcad03b0744d6833/tools/depends/target/ffmpeg/008-ffmpeg-all-pgssubdec-use-caller-colorspace.patch
+        sha256: 8bb37c1402dbdd5ee6aa8001944d0b6fea9aa6b5cf70cada7b0983f77c4822c4
+        dest-filename: 008-ffmpeg-all-pgssubdec-use-caller-colorspace.patch
       - type: shell
         commands:
           - patch -p1 < 001-ffmpeg-all-libpostproc-plugin.patch
+          - patch -p1 < 008-ffmpeg-all-pgssubdec-use-caller-colorspace.patch
       # v4l2-request hwaccel (from LibreELEC) targets stateless decoders found on aarch64 SoCs; x86_64 uses VAAPI
       - type: file
         url: https://raw.githubusercontent.com/LibreELEC/LibreELEC.tv/e9e6b8531df13bc9058ca1771dab5f0c4fd5e98e/packages/multimedia/ffmpeg/patches/v4l2-request/0001-v4l2-request.patch
@@ -626,8 +629,8 @@ modules:
       - /share/swig
     sources:
       - type: archive
-        url: http://prdownloads.sourceforge.net/swig/swig-4.5.0.tar.gz
-        sha256: 22ae0e887f8cca8031a325c67d005207653200b40e71edb3f88780e28e47d0ff
+        url: http://prdownloads.sourceforge.net/swig/swig-4.5.1.tar.gz
+        sha256: 7fec50b27deddab5455a9633780b6341eddfb96215a7619e93a76eb27178f653
         x-checker-data:
           type: anitya
           project-id: 4919
@@ -785,7 +788,6 @@ modules:
       - -DENABLE_LIRCCLIENT=ON
       - -DDEPENDS_PATH=/app
       - -DAPP_RENDER_SYSTEM=gles
-      - -DJava_JAVA_EXECUTABLE=/usr/lib/sdk/openjdk17/bin/java
       - -DCROSSGUID_URL=/app/tarballs/crossguid.tar.gz
       - -DLIBDVDCSS_URL=/app/tarballs/libdvdcss.tar.xz
       - -DLIBDVDCSS_HASH=SHA512=edd8b00af2621d1b8fb7eac818e9e7a763aabb1b2868d2fc56836b8a22d6d6bc1855b027125557263a6607c86e5d32214b86ab4e22ecb6ca51964abd22574ea0
@@ -797,7 +799,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/xbmc/xbmc.git
-        commit: e513e0ff4331fc25fd2454659a9dd3e6b7670146
+        commit: 4719e45848e3aeda84f07247fcad03b0744d6833
         x-checker-data:
           type: git
           tag-pattern: ^(\d+\.\d+(?:\w+)?(?:-\w+)?)$
@@ -834,28 +836,14 @@ modules:
         sha512: 4df6336050f3b79ca2edafac28dd0383b950272ba6d8ebe6e43a85eddc737ce740d72a3fc1fa03c26fc5f285125e3672a022555a5399259386b2036c467a47f3
         dest: build/download/
         dest-filename: libdvdnav.tar.xz
-      - type: file
-        url: https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-4.0.30.zip
-        sha512: 789e956ecad3c302d545a16caccd45454357556b566ee83abfafe102371cf218f5ed5dc83d748595fbb2d465bde6c7306a498806e58b512cfc742abe5f5b101d
-        dest: build/download/
-        dest-filename: apache-groovy-binary-4.0.30.zip
-      - type: file
-        url: https://archive.apache.org/dist/commons/lang/binaries/commons-lang3-3.20.0-bin.tar.gz
-        sha512: eead2c04a85c85cfc83ef8a858f954e7abf668367d5a42e1152eb5d656eb8f4c1d5e7ad03f46859e99393e92b0d5fc69c927301c1a2ca466a3c49fb1f186ce89
-        dest: build/download/
-        dest-filename: commons-lang3-3.20.0-bin.tar.gz
-      - type: file
-        url: https://archive.apache.org/dist/commons/text/binaries/commons-text-1.15.0-bin.tar.gz
-        sha512: 6d1fcbd85a85f38e95ea33c9ab7f58798723b0e6357077246a135c417e75c7b39e278ebdb77fcc8f9b56b52b1eeff113eea9463eaaaee8d38df9afdc149b6421
-        dest: build/download/
-        dest-filename: commons-text-1.15.0-bin.tar.gz
       - type: shell
         commands:
           - mkdir -p /app/tarballs
-          - mv build/download/*.tar.gz build/download/*.tar.xz build/download/*.zip
-            /app/tarballs/
+          - mv build/download/*.tar.gz build/download/*.tar.xz /app/tarballs/
     cleanup:
       - /tarballs
+      # PEP 484 stubs for addon authors, kodi-addon-dev material
+      - /share/kodi/python-stubs
 
   # pvr.argustv, pvr.filmon, pvr.pctv, pvr.stalker, visualization.shadertoy
   - name: jsoncpp

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -725,26 +725,6 @@ modules:
             x-checker-data:
               type: git
               tag-pattern: ^v([\d.]+)$
-  - name: taglib
-    buildsystem: cmake-ninja
-    builddir: true
-    cleanup:
-      - /bin
-    config-opts:
-      - -DBUILD_SHARED_LIBS=ON
-      - -DBUILD_EXAMPLES=OFF
-      - -DBUILD_TESTING=OFF
-      - -DWITH_ZLIB=ON
-      - -DCMAKE_INSTALL_LIBDIR=lib
-    sources:
-      - type: archive
-        url: https://taglib.org/releases/taglib-2.3.1.tar.gz
-        sha256: a19d90e6fd41d09a0281ec0fe762d51491d7a6ccffc923c4f7868c5e647ca230
-        x-checker-data:
-          type: anitya
-          project-id: 1982
-          stable-only: true
-          url-template: https://taglib.org/releases/taglib-$version.tar.gz
   - name: kodi
     buildsystem: cmake-ninja
     builddir: true


### PR DESCRIPTION
- runtime: 25.08 to 26.08
- kodi: bump to 4719e45848 (22.0b2-Piers + 132 commits), merges xbmc/xbmc#28958
- kodi: python bindings via swig 4.5.1, java/openjdk17/groovy dropped
- kodi: strip PEP 484 python stubs, they are kodi-addon-dev material
- ffmpeg: apply kodi's 008 pgssubdec patch so PGS subtitles get the video's colorimetry (xbmc/xbmc#29054, #29056)
- hwdata: dropped, 26.08 ships pnp.ids
- taglib: dropped, 26.08 ships 2.3.1
- dav1d: dropped, 26.08 ships 1.5.4
- imagedecoder.heif: use runtime libheif + codecs-extra, drop libheif/libde265 modules
- rtmpdump: patch for nettle 4.0 `*_digest` signature change
- libcec 8.1.7, libnfs 7.0.2, mariadb-connector-c 3.4.10
- addons: update to latest upstream, realign beetle-psx/pcsx-rearmed/swanstation core tarballs to their depends pins
