### PR TITLE
bdj: add optional BD-J extension for Blu-ray menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,26 @@ flatpak run tv.kodi.Kodi
 
 or just search for the installed app on your system
 
+## Blu-ray Java menus (BD-J)
+
+Many Blu-ray discs present their menus as a Java (BD-J) application. Support
+for these lives in a separate, optional Flatpak extension so that the app
+itself stays small: it bundles a trimmed Java runtime and adds roughly 50 MB.
+Discs still play without it, Kodi just falls back to the simple disc menu.
+
+```
+flatpak install flathub tv.kodi.Kodi.bdj
+```
+
+The extension also ships libbluray's `bd_info`, which reports whether BD-J was
+detected and whether a Java VM was found. Kodi's launcher sets up the
+environment automatically, but other commands do not, so source the extension's
+`env.sh` first:
+
+```
+flatpak run --command=sh tv.kodi.Kodi -c '. /app/share/kodi/extra/bdj/env.sh; bd_info /path/to/BDMV-or-iso'
+```
+
 ## Contributing
 
 The list of binary addons in each branch of Kodi may be found

--- a/extensions/bdj/env.sh
+++ b/extensions/bdj/env.sh
@@ -1,0 +1,3 @@
+export JAVA_HOME=/app/share/kodi/extra/bdj/jre
+export LIBBLURAY_CP=/app/share/kodi/extra/bdj/share/java/
+export PATH=/app/share/kodi/extra/bdj/bin:$JAVA_HOME/bin:$PATH

--- a/extensions/bdj/tv.kodi.Kodi.bdj.metainfo.xml
+++ b/extensions/bdj/tv.kodi.Kodi.bdj.metainfo.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>tv.kodi.Kodi.bdj</id>
+  <extends>tv.kodi.Kodi</extends>
+  <name>Kodi: Blu-ray Java menus (BD-J)</name>
+  <summary>Java runtime for Blu-ray disc menus</summary>
+  <description>
+    <p>
+      Adds the Java runtime and libbluray support classes that Kodi needs to
+      play the interactive BD-J menus found on many Blu-ray discs. Without it
+      such discs still play, but Kodi falls back to the simple disc menu.
+    </p>
+    <p>
+      This extension is optional and fairly large, so it is not installed
+      automatically. Install it only if you play Blu-ray discs or disc images.
+    </p>
+  </description>
+  <url type="homepage">https://kodi.tv/</url>
+  <developer id="tv.kodi">
+    <name>Team Kodi</name>
+  </developer>
+  <metadata_license>FSFAP</metadata_license>
+  <project_license>LGPL-2.1-or-later AND GPL-2.0-only WITH Classpath-exception-2.0</project_license>
+</component>

--- a/patches/kodi.sh.in.patch
+++ b/patches/kodi.sh.in.patch
@@ -1,6 +1,6 @@
 --- a/tools/Linux/kodi.sh.in
 +++ b/tools/Linux/kodi.sh.in
-@@ -26,8 +26,9 @@ exec_prefix="@exec_prefix@"
+@@ -26,8 +26,10 @@ exec_prefix="@exec_prefix@"
  datarootdir="@datarootdir@"
  LIBDIR="@libdir@"
  APP_BINARY=$LIBDIR/${bin_name}/@APP_BINARY@
@@ -9,6 +9,7 @@
 +export CRASHLOG_DIR=${XDG_DATA_HOME}
 +export KODI_DATA=${XDG_DATA_HOME}
 +export KODI_HOME=/app/share/kodi
++for f in /app/share/kodi/extra/*/env.sh; do if [ -f "$f" ]; then . "$f"; fi; done
  
  # Workaround for high CPU load with nvidia GFX
  export __GL_YIELD=USLEEP

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -2,6 +2,8 @@ app-id: tv.kodi.Kodi
 runtime: org.freedesktop.Platform
 runtime-version: '26.08'
 sdk: org.freedesktop.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.openjdk17
 command: kodi
 rename-icon: kodi
 rename-desktop-file: kodi.desktop
@@ -30,6 +32,13 @@ finish-args:
   - --system-talk-name=org.freedesktop.UPower
   - --talk-name=org.freedesktop.ScreenSaver
 
+add-extensions:
+  tv.kodi.Kodi.bdj:
+    directory: share/kodi/extra/bdj
+    bundle: true
+    autodelete: true
+    no-autodownload: true
+
 cleanup:
   - '*.a'
   - '*.la'
@@ -52,6 +61,8 @@ cleanup:
   - /share/locale
   - /share/man
   - /var
+cleanup-commands:
+  - mkdir -p ${FLATPAK_DEST}/share/kodi/extra
 modules:
   - name: avahi
     # ships only avahi-browse: inputstream.airplay shells out to it for DACP
@@ -268,13 +279,17 @@ modules:
         path: patches/libbdplus-fix-libgcrypt.patch
   - name: libbluray
     buildsystem: meson
+    build-options:
+      append-path: /usr/lib/sdk/openjdk17/bin
+      env:
+        JAVA_HOME: /usr/lib/sdk/openjdk17/jvm/openjdk-17
     config-opts:
       - -Ddefault_library=shared
       - -Denable_docs=false
-      - -Denable_tools=false
+      - -Denable_tools=true
       - -Denable_devtools=false
       - -Denable_examples=false
-      - -Dbdj_jar=disabled
+      - -Dbdj_jar=enabled
     sources:
       - type: archive
         url: https://download.videolan.org/pub/videolan/libbluray/1.5.0/libbluray-1.5.0.tar.xz
@@ -945,3 +960,27 @@ modules:
   - addons/visualization.spectrum/visualization.spectrum.json
   - addons/visualization.starburst/visualization.starburst.json
   - addons/visualization.waveform/visualization.waveform.json
+
+  - name: bdj
+    buildsystem: simple
+    build-options:
+      append-path: /usr/lib/sdk/openjdk17/bin
+      no-debuginfo: true # keep bdj last
+    build-commands:
+      - jlink --module-path /usr/lib/sdk/openjdk17/jvm/openjdk-17/jmods
+        --add-modules java.base,java.desktop,java.logging,java.rmi,java.xml
+        --strip-debug --no-man-pages --no-header-files --compress=2
+        --output ${FLATPAK_DEST}/share/kodi/extra/bdj/jre
+      - find ${FLATPAK_DEST}/share/kodi/extra/bdj/jre -type f \( -name '*.so' -o -path '*/bin/*' \)
+        -exec strip --strip-unneeded {} +
+      - install -Dm644 -t ${FLATPAK_DEST}/share/kodi/extra/bdj/share/java ${FLATPAK_DEST}/share/java/libbluray-*.jar
+        && rm -r ${FLATPAK_DEST}/share/java
+      - install -Dm755 -t ${FLATPAK_DEST}/share/kodi/extra/bdj/bin ${FLATPAK_DEST}/bin/bd_info
+      - rm ${FLATPAK_DEST}/bin/bd_info ${FLATPAK_DEST}/bin/bd_list_titles ${FLATPAK_DEST}/bin/bd_splice
+      - install -Dm644 env.sh ${FLATPAK_DEST}/share/kodi/extra/bdj/env.sh
+      - install -Dm644 -t ${FLATPAK_DEST}/share/kodi/extra/bdj/share/metainfo tv.kodi.Kodi.bdj.metainfo.xml
+    sources:
+      - type: file
+        path: extensions/bdj/env.sh
+      - type: file
+        path: extensions/bdj/tv.kodi.Kodi.bdj.metainfo.xml


### PR DESCRIPTION
Adds `tv.kodi.Kodi.bdj`, a bundled `no-autodownload` extension carrying a jlink-trimmed openjdk17 JRE (~46 MB), libbluray's BD-J jars and `bd_info`. libbluray already compiles its BD-J code and finds the JVM through `JAVA_HOME`/`LIBBLURAY_CP`, which the kodi wrapper now sources from `share/kodi/extra/*/env.sh`.
