### PR TITLE
beta updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ Android, Linux, BSD, macOS, iOS, tvOS and Windows operating systems, Kodi runs
 on most common processor architectures. This repository packages it through
 Flatpak.
 
+## Installing
+
+End-user instructions, including the beta channel, the optional BD-J extension
+and where Kodi keeps its data, are on the
+[Kodi wiki](https://kodi.wiki/view/HOW-TO:Install_Kodi_for_Linux#Flatpak).
+
 ## Building
 
 Then build via
@@ -22,21 +28,12 @@ flatpak run tv.kodi.Kodi
 
 or just search for the installed app on your system
 
-## Blu-ray Java menus (BD-J)
+## Debugging BD-J
 
-Many Blu-ray discs present their menus as a Java (BD-J) application. Support
-for these lives in a separate, optional Flatpak extension so that the app
-itself stays small: it bundles a trimmed Java runtime and adds roughly 50 MB.
-Discs still play without it, Kodi just falls back to the simple disc menu.
-
-```
-flatpak install flathub tv.kodi.Kodi.bdj
-```
-
-The extension also ships libbluray's `bd_info`, which reports whether BD-J was
-detected and whether a Java VM was found. Kodi's launcher sets up the
-environment automatically, but other commands do not, so source the extension's
-`env.sh` first:
+The `tv.kodi.Kodi.bdj` extension ships libbluray's `bd_info`, which reports
+whether BD-J was detected and whether a Java VM was found. Kodi's launcher sets
+up the environment automatically, but other commands do not, so source the
+extension's `env.sh` first:
 
 ```
 flatpak run --command=sh tv.kodi.Kodi -c '. /app/share/kodi/extra/bdj/env.sh; bd_info /path/to/BDMV-or-iso'

--- a/addons/game.libretro.beetle-psx/game.libretro.beetle-psx.json
+++ b/addons/game.libretro.beetle-psx/game.libretro.beetle-psx.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.beetle-psx",
-            "commit": "4f243867f69d9975968cd3d9df79d2fc151e2aee"
+            "commit": "53b9537782962945e2e077c2ffa254442ebda7ca"
         }
     ],
     "modules": [
@@ -35,8 +35,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/kodi-game/beetle-psx-libretro/archive/dbd9abe2801ea246d8cec2a5aefc9fd8b224bc8a.tar.gz",
-                    "sha256": "63d303cdddf5a1279559abeeed67f015cfa991f34ead923b34a29b2fbf1ae1a3"
+                    "url": "https://github.com/kodi-game/beetle-psx-libretro/archive/7efcb4d7298dab5731089724af2e5704634b80fe.tar.gz",
+                    "sha256": "30139696e6be63f09bbf3db817b93be7750a13b14f910f6dd3e27986c9986ea9"
                 }
             ]
         }

--- a/addons/game.libretro.blastem/game.libretro.blastem.json
+++ b/addons/game.libretro.blastem/game.libretro.blastem.json
@@ -16,7 +16,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.blastem",
-            "commit": "477495425bc8053f07adad98ab932be93f6b04fb"
+            "commit": "7195885e5a3e762d83dcc827c859420cfc4ab593"
         }
     ],
     "modules": [
@@ -38,8 +38,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/libretro/blastem/archive/aeb16cd0750fc23ab5e804efeb96f9b207985c41.tar.gz",
-                    "sha256": "c5d4c49a3c28ac481aeed85ec5e3b9c6d40c72bdacb44a459db99c09afe6facb"
+                    "url": "https://github.com/libretro/blastem/archive/b4d75247ebad8852fd9bc385b423df704c6c5af5.tar.gz",
+                    "sha256": "c1c216d39ab5d1401abd6da02938cb4b40fd52a033045ec49a25890b2dcc042d"
                 }
             ]
         }

--- a/addons/game.libretro.dosbox-pure/game.libretro.dosbox-pure.json
+++ b/addons/game.libretro.dosbox-pure/game.libretro.dosbox-pure.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.dosbox-pure",
-            "commit": "2aefa1087ab2a39575daf8dde85d0e69da1f60d4"
+            "commit": "22422f6f1d009cc9bac6a4304fae18eeb978c8cc"
         }
     ],
     "modules": [

--- a/addons/game.libretro.dosbox/game.libretro.dosbox.json
+++ b/addons/game.libretro.dosbox/game.libretro.dosbox.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.dosbox",
-            "commit": "ef1cdd028306d88f514f3e7cb3c15820a4715f3c"
+            "commit": "e8ae36c41316bb7a826f13da54e2bc2816dfc4bf"
         }
     ],
     "modules": [
@@ -35,8 +35,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/libretro/dosbox-libretro/archive/4024bf0048c261db58ef98cb5e16de291c429f4e.tar.gz",
-                    "sha256": "49582f2c3a3abcf32819d25ec428d6350e15742e4642c9da8cdac7b8a76e8d79"
+                    "url": "https://github.com/libretro/dosbox-libretro/archive/988aa330d10b1423873ebfd8dcb6106df2538c44.tar.gz",
+                    "sha256": "0355e888bf222d21a4d91e7cdd977f795d07ebf360007770f8d4b7e466a59e24"
                 }
             ]
         }

--- a/addons/game.libretro.fceumm/game.libretro.fceumm.json
+++ b/addons/game.libretro.fceumm/game.libretro.fceumm.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.fceumm",
-            "commit": "533f704643b793ff1a585d12bc33a905dc40db2c"
+            "commit": "407b05e922007a695db53051ad72084295c134ec"
         }
     ],
     "modules": [

--- a/addons/game.libretro.gambatte/game.libretro.gambatte.json
+++ b/addons/game.libretro.gambatte/game.libretro.gambatte.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.gambatte",
-            "commit": "7c51c8d445401ce24ba221489aa7797194b6b5fa"
+            "commit": "04976d9022b275fabff5f4a4582e33a31fa43627"
         }
     ],
     "modules": [

--- a/addons/game.libretro.pcsx-rearmed/game.libretro.pcsx-rearmed.json
+++ b/addons/game.libretro.pcsx-rearmed/game.libretro.pcsx-rearmed.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.pcsx-rearmed",
-            "commit": "60387e31f341c92e40cb63ba666d3bae01168afa"
+            "commit": "1dc82acc6831dbda616bb405bac343fadc4a9e46"
         }
     ],
     "modules": [

--- a/addons/game.libretro.quicknes/game.libretro.quicknes.json
+++ b/addons/game.libretro.quicknes/game.libretro.quicknes.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.quicknes",
-            "commit": "c9e9fc9e4a36c1fcce3735fc67491c28ae5a2939"
+            "commit": "b8c81eaca9df41f099799fa328a7afd50c8d721e"
         }
     ],
     "modules": [

--- a/addons/game.libretro.swanstation/game.libretro.swanstation.json
+++ b/addons/game.libretro.swanstation/game.libretro.swanstation.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.swanstation",
-            "commit": "a325083bc0c26b11c54a8674289c676b85f8f75b"
+            "commit": "d8c54c176235afdd993fdcd39f025f6562eea022"
         }
     ],
     "modules": [

--- a/addons/game.libretro.yabause/game.libretro.yabause.json
+++ b/addons/game.libretro.yabause/game.libretro.yabause.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro.yabause",
-            "commit": "5c5ce1bdf906d39cef7a39161b34400c697e076f"
+            "commit": "25f0852d6f8e5cd32754bf7aa57cf54589ac706c"
         }
     ],
     "modules": [

--- a/addons/game.libretro/game.libretro.json
+++ b/addons/game.libretro/game.libretro.json
@@ -18,7 +18,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.libretro",
-            "commit": "d0d6d3279c6621ae75c5dc5368f4aceea01cbfc1"
+            "commit": "c03fe79009620e80b3d795e7c565e4e0abbce782"
         }
     ],
     "modules": [
@@ -38,7 +38,7 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/kodi-game/game.libretro/d0d6d3279c6621ae75c5dc5368f4aceea01cbfc1/depends/common/libretro-common/CMakeLists.txt",
+                    "url": "https://raw.githubusercontent.com/kodi-game/game.libretro/c03fe79009620e80b3d795e7c565e4e0abbce782/depends/common/libretro-common/CMakeLists.txt",
                     "sha256": "e45d4f77e57478ba27e6bcfcab2f7b641061cea24efd836e3d082e45cd0b688f"
                 }
             ]
@@ -65,7 +65,7 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/kodi-game/game.libretro/d0d6d3279c6621ae75c5dc5368f4aceea01cbfc1/depends/common/rcheevos/CMakeLists.txt",
+                    "url": "https://raw.githubusercontent.com/kodi-game/game.libretro/c03fe79009620e80b3d795e7c565e4e0abbce782/depends/common/rcheevos/CMakeLists.txt",
                     "sha256": "49a8eb640f10ea35f98880f504048d07865627037bca1402039bb67fe28d1cc9"
                 }
             ]

--- a/addons/game.shader.presets/game.shader.presets.json
+++ b/addons/game.shader.presets/game.shader.presets.json
@@ -13,7 +13,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-game/game.shader.presets",
-            "commit": "a4c240f8c3a340bdd2d3f64894de386930ea579b"
+            "commit": "761e18021a7de668e88f0be90e8ca161a504e0fc"
         }
     ]
 }

--- a/addons/inputstream.airplay/inputstream.airplay.json
+++ b/addons/inputstream.airplay/inputstream.airplay.json
@@ -9,12 +9,12 @@
         {
             "type": "git",
             "url": "https://github.com/popcornmix/inputstream.airplay",
-            "commit": "18dfcae27b28cecd4a724a32b1b486449060f512"
+            "commit": "1d96497a0658167953e628779ab575e6bcd86738"
         },
         {
             "type": "archive",
-            "url": "https://github.com/FDH2/UxPlay/archive/462153392f2e30937424922039ff9f0cda5e7b1a.tar.gz",
-            "sha256": "0f5bf6f2ab3d1ac3ccaf4418afe00137ec1ba97c2a345710202fca40f6a1fb85",
+            "url": "https://github.com/FDH2/UxPlay/archive/d29dfabe102aba137170121077f55390e875310c.tar.gz",
+            "sha256": "d68b043bb7eaf141b506199f0c3aa4b8dc261b4f063cf8ccc9697f22b8539ce2",
             "dest": "uxplay"
         }
     ],

--- a/addons/pvr.hts/pvr.hts.json
+++ b/addons/pvr.hts/pvr.hts.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/kodi-pvr/pvr.hts",
-            "commit": "d908dd8b203f609630fc42d5197d55e3fe68e50e"
+            "commit": "0ca57b52c2058001e37fd8dde4cca7a6fdfed518"
         }
     ],
     "build-options": {

--- a/addons/pvr.mythtv/pvr.mythtv.json
+++ b/addons/pvr.mythtv/pvr.mythtv.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://github.com/janbar/pvr.mythtv",
-            "commit": "ffc12c7266092da23b15d71c9d98db7daa5724fd"
+            "commit": "940afcdec9507c7ef5f9d741ed546f3259740d9d"
         }
     ],
     "build-options": {

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -568,8 +568,8 @@ modules:
         PERL5LIB: /app/lib/perl5
     sources:
       - type: archive
-        url: https://download.samba.org/pub/samba/stable/samba-4.24.6.tar.gz
-        sha256: 810cc955acb367e9bde556dccfb50db177a02b7c553aa1629a0b905fa7616267
+        url: https://download.samba.org/pub/samba/stable/samba-4.24.7.tar.gz
+        sha256: 45b7747a47452eff2b2159a44cc63eb43690d339fd1069088e023a015fed06c7
         x-checker-data:
           type: anitya
           project-id: 4758

--- a/tv.kodi.Kodi.yml
+++ b/tv.kodi.Kodi.yml
@@ -764,7 +764,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/xbmc/xbmc.git
-        commit: 4719e45848e3aeda84f07247fcad03b0744d6833
+        commit: bfef4b5d57b18f3be99af2e6293b6b5375610a60
         x-checker-data:
           type: git
           tag-pattern: ^(\d+\.\d+(?:\w+)?(?:-\w+)?)$


### PR DESCRIPTION
- kodi: bump to bfef4b5d57 (22.0b2-Piers + 252 commits), includes xbmc/xbmc#29264: the swig bindings accept None in dict values and list elements again (xbmc/xbmc#29254), `with xbmcvfs.File()` works again (xbmc/xbmc#29263), int64_t arguments such as ListItem.setSize take a python int; restores slyguy Freeview AU, Jellyfin and YouTube playback. Also picks up xbmc/xbmc#29126 (fullscreen window cleared while no renderer is active, fixes start stutter on Linux), #29210 (disc state persisted in savestates), #29278 (new game OSD layout), #29191 (hardened stacking) and #29082 (scraping speedups)
- samba 4.24.7
- addons: update to latest upstream, realign beetle-psx core tarball, game.libretro libretro-common/rcheevos companions and UxPlay (inputstream.airplay) to their depends pins; blastem and dosbox core tarballs aligned to depends
- game.libretro: back on the Piers branch head now that kodi-game/game.libretro#162 has merged
- README: point users at the Kodi wiki Flatpak section for install, beta channel, BD-J and data locations
